### PR TITLE
Add missing kDims member to SIMD vector specializations

### DIFF
--- a/include/mathfu/internal/vector_2.h
+++ b/include/mathfu/internal/vector_2.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2016 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_INTERNAL_VECTOR_2_H_
 #define MATHFU_INTERNAL_VECTOR_2_H_
 
@@ -25,23 +25,19 @@ class Vector<T, 2> {
  public:
   typedef T Scalar;
   static const int Dims = 2;
+  static const int kDims = 2;
 
   inline Vector() {}
 
-  inline Vector(const Vector<T, 2>& v)
-      : x(v.x), y(v.y) {}
+  inline Vector(const Vector<T, 2>& v) : x(v.x), y(v.y) {}
 
-  explicit inline Vector(const VectorPacked<T, 2>& v)
-      : x(v.x), y(v.y) {}
+  explicit inline Vector(const VectorPacked<T, 2>& v) : x(v.x), y(v.y) {}
 
-  explicit inline Vector(const T* a)
-      : x(a[0]), y(a[1]) {}
+  explicit inline Vector(const T* a) : x(a[0]), y(a[1]) {}
 
-  explicit inline Vector(T s)
-      : x(s), y(s) {}
+  explicit inline Vector(T s) : x(s), y(s) {}
 
-  inline Vector(T s1, T s2)
-      : x(s1), y(s2) {}
+  inline Vector(T s1, T s2) : x(s1), y(s2) {}
 
   template <typename U>
   explicit inline Vector(const Vector<U, 2>& v)

--- a/include/mathfu/internal/vector_2_simd.h
+++ b/include/mathfu/internal/vector_2_simd.h
@@ -1,25 +1,25 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_VECTOR_2_SIMD_H_
 #define MATHFU_VECTOR_2_SIMD_H_
 
+#include <math.h>
+
 #include "mathfu/internal/vector_2.h"
 #include "mathfu/utilities.h"
-
-#include <math.h>
 
 /// @file mathfu/internal/vector_2_simd.h MathFu Vector<T, 2> Specialization
 /// @brief 2-dimensional specialization of mathfu::Vector for SIMD optimized
@@ -38,6 +38,7 @@ template <>
 class Vector<float, 2> {
  public:
   typedef float Scalar;
+  static const int kDims = 2;
 
   inline Vector() {}
 

--- a/include/mathfu/internal/vector_3.h
+++ b/include/mathfu/internal/vector_3.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2016 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_INTERNAL_VECTOR_3_H_
 #define MATHFU_INTERNAL_VECTOR_3_H_
 
@@ -25,26 +25,22 @@ class Vector<T, 3> {
  public:
   typedef T Scalar;
   static const int Dims = 3;
+  static const int kDims = 3;
 
   inline Vector() {}
 
-  inline Vector(const Vector<T, 3>& v)
-      : x(v.x), y(v.y), z(v.z) {}
+  inline Vector(const Vector<T, 3>& v) : x(v.x), y(v.y), z(v.z) {}
 
   explicit inline Vector(const VectorPacked<T, 3>& v)
       : x(v.x), y(v.y), z(v.z) {}
 
-  explicit inline Vector(const T* a)
-      : x(a[0]), y(a[1]), z(a[2]) {}
+  explicit inline Vector(const T* a) : x(a[0]), y(a[1]), z(a[2]) {}
 
-  explicit inline Vector(T s)
-      : x(s), y(s), z(s) {}
+  explicit inline Vector(T s) : x(s), y(s), z(s) {}
 
-  inline Vector(T s1, T s2, T s3)
-      : x(s1), y(s2), z(s3) {}
+  inline Vector(T s1, T s2, T s3) : x(s1), y(s2), z(s3) {}
 
-  inline Vector(const Vector<T, 2>& v12, T s3)
-      : x(v12.x), y(v12.y), z(s3) {}
+  inline Vector(const Vector<T, 2>& v12, T s3) : x(v12.x), y(v12.y), z(s3) {}
 
   template <typename U>
   explicit inline Vector(const Vector<U, 3>& v)

--- a/include/mathfu/internal/vector_3_simd.h
+++ b/include/mathfu/internal/vector_3_simd.h
@@ -1,25 +1,25 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_VECTOR_3_SIMD_H_
 #define MATHFU_VECTOR_3_SIMD_H_
 
+#include <math.h>
+
 #include "mathfu/internal/vector_3.h"
 #include "mathfu/utilities.h"
-
-#include <math.h>
 
 #ifdef MATHFU_COMPILE_WITH_SIMD
 #include "vectorial/simd4f.h"
@@ -40,13 +40,19 @@
 /// not.
 #ifdef MATHFU_COMPILE_WITH_PADDING
 #define MATHFU_VECTOR3_STORE3(simd_to_store, data) \
-  { (data).simd3 = simd_to_store; }
+  {                                                \
+    (data).simd3 = simd_to_store;                  \
+  }
 #define MATHFU_VECTOR3_LOAD3(data) (data).simd3
-#define MATHFU_VECTOR3_INIT3(data, v1, v2, v3) \
-  { (data).simd3 = simd4f_create(v1, v2, v3, 0); }
+#define MATHFU_VECTOR3_INIT3(data, v1, v2, v3)   \
+  {                                              \
+    (data).simd3 = simd4f_create(v1, v2, v3, 0); \
+  }
 #else
 #define MATHFU_VECTOR3_STORE3(simd_to_store, data) \
-  { simd4f_ustore3(simd_to_store, (data).data_); }
+  {                                                \
+    simd4f_ustore3(simd_to_store, (data).data_);   \
+  }
 #define MATHFU_VECTOR3_LOAD3(data) simd4f_uload3((data).data_)
 #define MATHFU_VECTOR3_INIT3(data, v1, v2, v3) \
   {                                            \
@@ -66,6 +72,7 @@ template <>
 class Vector<float, 3> {
  public:
   typedef float Scalar;
+  static const int kDims = 3;
 
   inline Vector() {}
 

--- a/include/mathfu/internal/vector_4.h
+++ b/include/mathfu/internal/vector_4.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2016 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_INTERNAL_VECTOR_4_H_
 #define MATHFU_INTERNAL_VECTOR_4_H_
 
@@ -26,23 +26,20 @@ class Vector<T, 4> {
  public:
   typedef T Scalar;
   static const int Dims = 4;
+  static const int kDims = 4;
 
   inline Vector() {}
 
-  inline Vector(const Vector<T, 4>& v)
-      : x(v.x), y(v.y), z(v.z), w(v.w) {}
+  inline Vector(const Vector<T, 4>& v) : x(v.x), y(v.y), z(v.z), w(v.w) {}
 
   explicit inline Vector(const VectorPacked<T, 4>& v)
       : x(v.x), y(v.y), z(v.z), w(v.w) {}
 
-  explicit inline Vector(const T* a)
-      : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
+  explicit inline Vector(const T* a) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
 
-  explicit inline Vector(T s)
-      : x(s), y(s), z(s), w(s) {}
+  explicit inline Vector(T s) : x(s), y(s), z(s), w(s) {}
 
-  inline Vector(T s1, T s2, T s3, T s4)
-      : x(s1), y(s2), z(s3), w(s4) {}
+  inline Vector(T s1, T s2, T s3, T s4) : x(s1), y(s2), z(s3), w(s4) {}
 
   inline Vector(const Vector<T, 3>& v123, T s4)
       : x(v123.x), y(v123.y), z(v123.z), w(s4) {}

--- a/include/mathfu/internal/vector_4_simd.h
+++ b/include/mathfu/internal/vector_4_simd.h
@@ -1,25 +1,25 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_VECTOR_4_SIMD_H_
 #define MATHFU_VECTOR_4_SIMD_H_
 
+#include <math.h>
+
 #include "mathfu/internal/vector_4.h"
 #include "mathfu/utilities.h"
-
-#include <math.h>
 
 #ifdef MATHFU_COMPILE_WITH_SIMD
 #include "vectorial/simd4f.h"
@@ -38,6 +38,7 @@ template <>
 class Vector<float, 4> {
  public:
   typedef float Scalar;
+  static const int kDims = 4;
 
   inline Vector() {}
 

--- a/include/mathfu/vector.h
+++ b/include/mathfu/vector.h
@@ -1,26 +1,26 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_VECTOR_H_
 #define MATHFU_VECTOR_H_
 
 #include <math.h>
+
 #include <cmath>
 
 #include "mathfu/utilities.h"
-
 
 /// @file mathfu/vector.h Vector
 /// @brief Vector class and functions.
@@ -162,6 +162,8 @@ class Vector {
  public:
   /// @brief Element type to enable reference by other classes.
   typedef T Scalar;
+  /// @brief The number of dimensions in this Vector.
+  static const int kDims = Dims;
 
   /// @brief Create an uninitialized Vector.
   inline Vector() {}
@@ -942,11 +944,10 @@ inline T AngleHelper(const Vector<T, Dims>& v1, const Vector<T, Dims>& v2) {
 ///
 /// @tparam T Type of vector components to test.
 template <class T>
-bool InRange2D(const Vector<T, 2>& val,
-               const Vector<T, 2>& range_start,
+bool InRange2D(const Vector<T, 2>& val, const Vector<T, 2>& range_start,
                const Vector<T, 2>& range_end) {
-  return InRange(val[0], range_start[0], range_end[0]) &&
-         InRange(val[1], range_start[1], range_end[1]);
+  return InRange(val[0], range_start[0], range_end[0])
+         && InRange(val[1], range_start[1], range_end[1]);
 }
 
 /// @cond MATHFU_INTERNAL

--- a/unit_tests/vector_test/vector_test.cpp
+++ b/unit_tests/vector_test/vector_test.cpp
@@ -1,28 +1,27 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "mathfu/vector.h"
-#include "mathfu/constants.h"
-#include "mathfu/io.h"
-
-#include "gtest/gtest.h"
-
-#include "precision.h"
 
 #include <sstream>
 #include <string>
+
+#include "gtest/gtest.h"
+#include "mathfu/constants.h"
+#include "mathfu/io.h"
+#include "precision.h"
 
 class VectorTests : public ::testing::Test {
  protected:
@@ -200,8 +199,8 @@ void InitializationPacked_Test(const T& precision) {
   }
   mathfu::Vector<T, d> unpacked(packed);
   for (int i = 0; i < d; ++i) {
-    EXPECT_NEAR(packed.data_[i], unpacked[i], static_cast<T>(0)) << "Element "
-                                                                << i;
+    EXPECT_NEAR(packed.data_[i], unpacked[i], static_cast<T>(0))
+        << "Element " << i;
   }
 }
 TEST_ALL_F(InitializationPacked)
@@ -913,7 +912,8 @@ void FromType_Test(const T& precision) {
     compatible.values[i] = static_cast<T>(i * precision);
   }
 
-  const mathfu::Vector<T, d> vector = mathfu::Vector<T, d>::FromType(compatible);
+  const mathfu::Vector<T, d> vector =
+      mathfu::Vector<T, d>::FromType(compatible);
 
   for (int i = 0; i < d; ++i) {
     EXPECT_EQ(compatible.values[i], vector[i]);
@@ -975,6 +975,14 @@ TEST_ALL_F(OutputStream)
 TEST_ALL_INTS_F(OutputStream)
 TEST_F(VectorTests, OutputStream_Test_float_1) {
   OutputStream_Test<float, 1>(0.0f);
+}
+
+// Test that the kDims static member is present and correct for each
+// specialization.
+TEST_F(VectorTests, kDims) {
+  EXPECT_EQ(mathfu::Vector<float, 2>::kDims, 2);
+  EXPECT_EQ(mathfu::Vector<float, 3>::kDims, 3);
+  EXPECT_EQ(mathfu::Vector<float, 4>::kDims, 4);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
The SIMD specializations of Vector<float, 2>, Vector<float, 3>, and Vector<float, 4> were missing the static kDims member, causing compile failures when code accessed Vector<float, N>::kDims with SIMD enabled.

Also adds kDims to the generic Vector template and the non-SIMD specializations for completeness, and a test verifying the value is correct for dimensions 2, 3, and 4.