### PR TITLE
Fix Matrix operator!= using bitwise OR instead of logical OR

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -1,27 +1,27 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_MATRIX_H_
 #define MATHFU_MATRIX_H_
 
-#include "mathfu/utilities.h"
-#include "mathfu/vector.h"
+#include <assert.h>
 
 #include <cmath>
 
-#include <assert.h>
+#include "mathfu/utilities.h"
+#include "mathfu/vector.h"
 
 /// @file mathfu/matrix.h
 /// @brief Matrix class and functions.
@@ -62,7 +62,7 @@
 /// This will perform a given OP on each matrix column and return the result
 #define MATHFU_MAT_OPERATOR(OP)                   \
   {                                               \
-    Matrix<T, Rows, Cols> result;              \
+    Matrix<T, Rows, Cols> result;                 \
     MATHFU_MAT_OPERATION(result.data_[i] = (OP)); \
     return result;                                \
   }
@@ -80,15 +80,15 @@
 /// @cond MATHFU_INTERNAL
 /// This macro will take the dot product for a row from data1 and a column from
 /// data2.
-#define MATHFU_MATRIX_4X4_DOT(data1, data2, r)               \
-  ((data1)[r] * (data2)[0] + (data1)[(r) + 4] * (data2)[1] + \
-   (data1)[(r) + 8] * (data2)[2] + (data1)[(r) + 12] * (data2)[3])
+#define MATHFU_MATRIX_4X4_DOT(data1, data2, r)             \
+  ((data1)[r] * (data2)[0] + (data1)[(r) + 4] * (data2)[1] \
+   + (data1)[(r) + 8] * (data2)[2] + (data1)[(r) + 12] * (data2)[3])
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
-#define MATHFU_MATRIX_3X3_DOT(data1, data2, r, size)              \
-  ((data1)[r] * (data2)[0] + (data1)[(r) + (size)] * (data2)[1] + \
-   (data1)[(r) + 2 * (size)] * (data2)[2])
+#define MATHFU_MATRIX_3X3_DOT(data1, data2, r, size)            \
+  ((data1)[r] * (data2)[0] + (data1)[(r) + (size)] * (data2)[1] \
+   + (data1)[(r) + 2 * (size)] * (data2)[2])
 /// @endcond
 
 namespace mathfu {
@@ -99,9 +99,8 @@ class Matrix;
 template <class T, int Rows, int Cols>
 inline Matrix<T, Rows, Cols> IdentityHelper();
 template <bool check_invertible, class T, int Rows, int Cols>
-inline bool InverseHelper(
-    const Matrix<T, Rows, Cols>& m, Matrix<T, Rows, Cols>* const inverse,
-    T det_thresh);
+inline bool InverseHelper(const Matrix<T, Rows, Cols>& m,
+                          Matrix<T, Rows, Cols>* const inverse, T det_thresh);
 template <class T, int size1, int size2, int size3>
 inline void TimesHelper(const Matrix<T, size1, size2>& m1,
                         const Matrix<T, size2, size3>& m2,
@@ -129,7 +128,8 @@ static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
                                    Vector<T, 3>& result);
 
 template <typename T, int Rows, int Cols, typename CompatibleT>
-static inline Matrix<T, Rows, Cols> FromTypeHelper(const CompatibleT& compatible);
+static inline Matrix<T, Rows, Cols> FromTypeHelper(
+    const CompatibleT& compatible);
 
 template <typename T, int Rows, int Cols, typename CompatibleT>
 static inline CompatibleT ToTypeHelper(const Matrix<T, Rows, Cols>& m);
@@ -418,8 +418,7 @@ class Matrix {
   ///
   /// @param m Matrix to add to this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator+(
-      const Matrix<T, Rows, Cols>& m) const {
+  inline Matrix<T, Rows, Cols> operator+(const Matrix<T, Rows, Cols>& m) const {
     MATHFU_MAT_OPERATOR(data_[i] + m.data_[i]);
   }
 
@@ -427,8 +426,7 @@ class Matrix {
   ///
   /// @param m Matrix to subtract from this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator-(
-      const Matrix<T, Rows, Cols>& m) const {
+  inline Matrix<T, Rows, Cols> operator-(const Matrix<T, Rows, Cols>& m) const {
     MATHFU_MAT_OPERATOR(data_[i] - m.data_[i]);
   }
 
@@ -468,8 +466,7 @@ class Matrix {
   ///
   /// @param m Matrix to multiply with this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator*(
-      const Matrix<T, Rows, Cols>& m) const {
+  inline Matrix<T, Rows, Cols> operator*(const Matrix<T, Rows, Cols>& m) const {
     Matrix<T, Rows, Cols> result;
     TimesHelper(*this, m, &result);
     return result;
@@ -479,8 +476,7 @@ class Matrix {
   ///
   /// @param m Matrix to add to this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator+=(
-      const Matrix<T, Rows, Cols>& m) {
+  inline Matrix<T, Rows, Cols>& operator+=(const Matrix<T, Rows, Cols>& m) {
     MATHFU_MAT_SELF_OPERATOR(data_[i] += m.data_[i]);
   }
 
@@ -488,8 +484,7 @@ class Matrix {
   ///
   /// @param m Matrix to subtract from this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator-=(
-      const Matrix<T, Rows, Cols>& m) {
+  inline Matrix<T, Rows, Cols>& operator-=(const Matrix<T, Rows, Cols>& m) {
     MATHFU_MAT_SELF_OPERATOR(data_[i] -= m.data_[i]);
   }
 
@@ -521,16 +516,13 @@ class Matrix {
   ///
   /// @param s Scalar to divide this Matrix by.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator/=(T s) {
-    return (*this) *= (1 / s);
-  }
+  inline Matrix<T, Rows, Cols>& operator/=(T s) { return (*this) *= (1 / s); }
 
   /// @brief Multiply this Matrix with another Matrix (in-place).
   ///
   /// @param m Matrix to multiply with this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator*=(
-      const Matrix<T, Rows, Cols>& m) {
+  inline Matrix<T, Rows, Cols>& operator*=(const Matrix<T, Rows, Cols>& m) {
     const Matrix<T, Rows, Cols> copy_of_this(*this);
     TimesHelper(copy_of_this, m, this);
     return *this;
@@ -574,8 +566,9 @@ class Matrix {
   inline Matrix<T, Cols, Rows> Transpose() const {
     Matrix<T, Cols, Rows> transpose;
     MATHFU_UNROLLED_LOOP(
-        i, Cols, MATHFU_UNROLLED_LOOP(
-                        j, Rows, transpose.GetColumn(j)[i] = GetColumn(i)[j]))
+        i, Cols,
+        MATHFU_UNROLLED_LOOP(j, Rows,
+                             transpose.GetColumn(j)[i] = GetColumn(i)[j]))
     return transpose;
   }
 
@@ -604,8 +597,7 @@ class Matrix {
   /// @return Vector with the scale along each local axis.
   inline Vector<T, 3> ScaleVector3D() const {
     MATHFU_STATIC_ASSERT(Rows >= 3 && Cols >= 3);
-    return Vector<T, 3>(data_[0].xyz().Length(),
-                        data_[1].xyz().Length(),
+    return Vector<T, 3>(data_[0].xyz().Length(), data_[1].xyz().Length(),
                         data_[2].xyz().Length());
   }
 
@@ -650,8 +642,8 @@ class Matrix {
   /// @brief Calculate the outer product of two Vectors.
   ///
   /// @return Matrix containing the result.
-  static inline Matrix<T, Rows, Cols> OuterProduct(
-      const Vector<T, Rows>& v1, const Vector<T, Cols>& v2) {
+  static inline Matrix<T, Rows, Cols> OuterProduct(const Vector<T, Rows>& v1,
+                                                   const Vector<T, Cols>& v2) {
     return OuterProductHelper(v1, v2);
   }
 
@@ -729,8 +721,7 @@ class Matrix {
   /// @param m 4x4 Matrix.
   /// @return rotation Matrix containing the result.
   static inline Matrix<T, 3> ToRotationMatrix(const Matrix<T, 4>& m) {
-    return Matrix<T, 3>(m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9],
-                        m[10]);
+    return Matrix<T, 3>(m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]);
   }
 
   /// @brief Constructs a Matrix<float, 4> from an AffineTransform.
@@ -894,8 +885,8 @@ class Matrix {
   /// @param v Vector to multiply.
   /// @param m Matrix to multiply.
   /// @return Matrix containing the result.
-  friend inline Vector<T, Cols> operator*(
-      const Vector<T, Rows>& v, const Matrix<T, Rows, Cols>& m) {
+  friend inline Vector<T, Cols> operator*(const Vector<T, Rows>& v,
+                                          const Matrix<T, Rows, Cols>& m) {
     const int Dims = Cols;
     MATHFU_VECTOR_OPERATOR((Vector<T, Rows>::DotProduct(m.data_[i], v)));
   }
@@ -918,18 +909,20 @@ class Matrix {
 /// @{
 
 /// @cond MATHFU_INTERNAL
-template <int index> struct MathfuMatrixUnroller {
+template <int index>
+struct MathfuMatrixUnroller {
   template <class T, int Rows, int Cols>
   inline static bool NotEqual(const Matrix<T, Rows, Cols>& lhs,
-                       const Matrix<T, Rows, Cols>& rhs) {
-    return (lhs[index] != rhs[index]) |
-           MathfuMatrixUnroller<index-1>::NotEqual(lhs, rhs);
+                              const Matrix<T, Rows, Cols>& rhs) {
+    return (lhs[index] != rhs[index])
+           || MathfuMatrixUnroller<index - 1>::NotEqual(lhs, rhs);
   }
 };
-template <> struct MathfuMatrixUnroller<0> {
+template <>
+struct MathfuMatrixUnroller<0> {
   template <class T, int Rows, int Cols>
   inline static bool NotEqual(const Matrix<T, Rows, Cols>& lhs,
-                       const Matrix<T, Rows, Cols>& rhs) {
+                              const Matrix<T, Rows, Cols>& rhs) {
     return lhs[0] != rhs[0];
   }
 };
@@ -1259,8 +1252,7 @@ static inline Matrix<T, 4, 4> OuterProductHelper(const Vector<T, 4>& v1,
 /// Matrix is invertible.
 template <bool check_invertible, class T, int Rows, int Cols>
 inline bool InverseHelper(const Matrix<T, Rows, Cols>& m,
-                          Matrix<T, Rows, Cols>* const inverse,
-                          T det_thresh) {
+                          Matrix<T, Rows, Cols>* const inverse, T det_thresh) {
   assert(false);
   (void)m;
   *inverse = T::Identity();
@@ -1368,8 +1360,8 @@ bool InverseHelper(const Matrix<T, 4, 4>& m, Matrix<T, 4, 4>* const inverse,
         Matrix<T, 3>(m[4], m[5], m[6], m[8], m[9], m[10], m[12], m[13], m[14]);
   }
   T pivot_value = m[pivot_elem];
-  if (check_invertible &&
-      fabs(pivot_value) < Constants<T>::GetDeterminantThreshold()) {
+  if (check_invertible
+      && fabs(pivot_value) < Constants<T>::GetDeterminantThreshold()) {
     return false;
   }
   // This will compute the inverse using the row, column, and 3x3 submatrix.
@@ -1377,8 +1369,8 @@ bool InverseHelper(const Matrix<T, 4, 4>& m, Matrix<T, 4, 4>* const inverse,
   row *= inv;
   matrix += Matrix<T, 3>::OuterProduct(column, row);
   Matrix<T, 3> mat_inverse;
-  if (!InverseHelper<check_invertible>(matrix, &mat_inverse, det_thresh) &&
-      check_invertible) {
+  if (!InverseHelper<check_invertible>(matrix, &mat_inverse, det_thresh)
+      && check_invertible) {
     return false;
   }
   Vector<T, 3> col_inverse = mat_inverse * (column * inv);
@@ -1513,8 +1505,8 @@ static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
                                    const float window_width,
                                    const float window_height,
                                    Vector<T, 3>& result) {
-  if (window_coord.z < static_cast<T>(0) ||
-      window_coord.z > static_cast<T>(1)) {
+  if (window_coord.z < static_cast<T>(0)
+      || window_coord.z > static_cast<T>(1)) {
     // window_coord.z should be with in [0, 1]
     // 0: near plane
     // 1: far plane
@@ -1522,10 +1514,10 @@ static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
   }
   Matrix<T, 4, 4> matrix = (projection * model_view).Inverse();
   Vector<T, 4> standardized = Vector<T, 4>(
-      static_cast<T>(2) * (window_coord.x - window_width) / window_width +
-          static_cast<T>(1),
-      static_cast<T>(2) * (window_coord.y - window_height) / window_height +
-          static_cast<T>(1),
+      static_cast<T>(2) * (window_coord.x - window_width) / window_width
+          + static_cast<T>(1),
+      static_cast<T>(2) * (window_coord.y - window_height) / window_height
+          + static_cast<T>(1),
       static_cast<T>(2) * window_coord.z - static_cast<T>(1),
       static_cast<T>(1));
 
@@ -1540,7 +1532,8 @@ static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
 
 /// @cond MATHFU_INTERNAL
 template <typename T, int Rows, int Cols, typename CompatibleT>
-static inline Matrix<T, Rows, Cols> FromTypeHelper(const CompatibleT& compatible) {
+static inline Matrix<T, Rows, Cols> FromTypeHelper(
+    const CompatibleT& compatible) {
 // C++11 is required for constructed unions.
 #if __cplusplus >= 201103L
   // Use a union instead of reinterpret_cast to avoid aliasing bugs.
@@ -1549,7 +1542,8 @@ static inline Matrix<T, Rows, Cols> FromTypeHelper(const CompatibleT& compatible
     CompatibleT compatible;
     VectorPacked<T, Rows> packed[Cols];
   } u;
-  static_assert(sizeof(u.compatible) == sizeof(u.packed), "Conversion size mismatch.");
+  static_assert(sizeof(u.compatible) == sizeof(u.packed),
+                "Conversion size mismatch.");
 
   // The read of `compatible` and write to `u.compatible` gets optimized away,
   // and this becomes essentially a safe reinterpret_cast.
@@ -1584,7 +1578,8 @@ static inline CompatibleT ToTypeHelper(const Matrix<T, Rows, Cols>& m) {
     CompatibleT compatible;
     VectorPacked<T, Rows> packed[Cols];
   } u;
-  static_assert(sizeof(u.compatible) == sizeof(u.packed), "Conversion size mismatch.");
+  static_assert(sizeof(u.compatible) == sizeof(u.packed),
+                "Conversion size mismatch.");
   m.Pack(u.packed);
   return u.compatible;
 #else

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -1,31 +1,29 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "mathfu/matrix.h"
-
-#include "mathfu/io.h"
-#include "mathfu/quaternion.h"
-#include "mathfu/utilities.h"
-#include "mathfu/vector.h"
 
 #include <cmath>
 #include <sstream>
 #include <string>
 
 #include "gtest/gtest.h"
-
+#include "mathfu/io.h"
+#include "mathfu/quaternion.h"
+#include "mathfu/utilities.h"
+#include "mathfu/vector.h"
 #include "precision.h"
 static const float kUnProjectFloatPrecision = 0.0012f;
 static const double kLookAtDoublePrecision = 1e-8;
@@ -290,12 +288,8 @@ void Mult_Test(const T& precision) {
   }
 }
 TEST_ALL_F(Mult, FLOAT_PRECISION, DOUBLE_PRECISION)
-TEST_F(MatrixTests, Mult_float_5) {
-  Mult_Test<float, 5>(FLOAT_PRECISION);
-}
-TEST_F(MatrixTests, Mult_double_5) {
-  Mult_Test<double, 5>(DOUBLE_PRECISION);
-}
+TEST_F(MatrixTests, Mult_float_5) { Mult_Test<float, 5>(FLOAT_PRECISION); }
+TEST_F(MatrixTests, Mult_double_5) { Mult_Test<double, 5>(DOUBLE_PRECISION); }
 
 // This will test the outer product of two vectors. The template parameter d
 // corresponds to the number of rows and columns.
@@ -339,10 +333,8 @@ void InverseNonInvertible_Test(const T& precision) {
   const size_t matrix_size = sizeof(m) / sizeof(m[0]);
   static const T kDeterminantThreshold =
       mathfu::Constants<T>::GetDeterminantThreshold();
-  static const T kDeterminantThresholdSmall =
-      kDeterminantThreshold / 100;
-  static const T kDeterminantThresholdLarge =
-      kDeterminantThreshold * 100;
+  static const T kDeterminantThresholdSmall = kDeterminantThreshold / 100;
+  static const T kDeterminantThresholdLarge = kDeterminantThreshold * 100;
   static const T kDeterminantThresholdInverse = 1 / kDeterminantThreshold;
   static const T kDeterminantThresholdInverseSmall =
       kDeterminantThresholdInverse / 100;
@@ -409,10 +401,8 @@ void InverseSmallScale_Test(const T& precision) {
   (void)precision;
   static const T kDeterminantThreshold =
       mathfu::Constants<T>::GetDeterminantThreshold();
-  static const T kDeterminantThresholdSmall =
-      kDeterminantThreshold / 100;
-  static const T kDeterminantThresholdLarge =
-      kDeterminantThreshold * 100;
+  static const T kDeterminantThresholdSmall = kDeterminantThreshold / 100;
+  static const T kDeterminantThresholdLarge = kDeterminantThreshold * 100;
 
   // The scale of the determinant grows with the square for 2x2 matrices, and
   // with the cube for both 3x3 and 4x4 matrices.
@@ -426,8 +416,8 @@ void InverseSmallScale_Test(const T& precision) {
   {
     for (int i = 0; i != d; ++i) matrix(i, i) = kScaleMin / 2;
     EXPECT_FALSE(matrix.InverseWithDeterminantCheck(&inverse_matrix));
-    EXPECT_TRUE(matrix.InverseWithDeterminantCheck(
-        &inverse_matrix, kDeterminantThresholdSmall));
+    EXPECT_TRUE(matrix.InverseWithDeterminantCheck(&inverse_matrix,
+                                                   kDeterminantThresholdSmall));
     EXPECT_FALSE(matrix.InverseWithDeterminantCheck(
         &inverse_matrix, kDeterminantThresholdLarge));
   }
@@ -436,8 +426,8 @@ void InverseSmallScale_Test(const T& precision) {
   {
     for (int i = 0; i != d; ++i) matrix(i, i) = kScaleMin * 2;
     EXPECT_TRUE(matrix.InverseWithDeterminantCheck(&inverse_matrix));
-    EXPECT_TRUE(matrix.InverseWithDeterminantCheck(
-        &inverse_matrix, kDeterminantThresholdSmall));
+    EXPECT_TRUE(matrix.InverseWithDeterminantCheck(&inverse_matrix,
+                                                   kDeterminantThresholdSmall));
     EXPECT_FALSE(matrix.InverseWithDeterminantCheck(
         &inverse_matrix, kDeterminantThresholdLarge));
   }
@@ -1087,8 +1077,9 @@ void Mat4ToAndFromAffine_Test(const T&) {
   // Perform a normal mat4 * mat4 multiplication and compare its result with
   // multiplications involving conversions.
   const Mat4 mat4_multiplication = indices4 * indices4;
-  const Mat4 affine_multiplication = Mat4::FromAffineTransform(indices_affine) *
-                                     Mat4::FromAffineTransform(indices_affine);
+  const Mat4 affine_multiplication =
+      Mat4::FromAffineTransform(indices_affine)
+      * Mat4::FromAffineTransform(indices_affine);
   const Mat4 affine_and_mat4_multiplication =
       indices4 * Mat4::FromAffineTransform(indices_affine);
 
@@ -1195,8 +1186,7 @@ void HadamardProduct_Test(const T& precision) {
     m1[i] = static_cast<T>(i + 1);
     m2[i] = static_cast<T>(d * d - i);
   }
-  mathfu::Matrix<T, d> result =
-      mathfu::Matrix<T, d>::HadamardProduct(m1, m2);
+  mathfu::Matrix<T, d> result = mathfu::Matrix<T, d>::HadamardProduct(m1, m2);
   for (int i = 0; i < d * d; ++i) {
     EXPECT_NEAR(result[i], m1[i] * m2[i], precision);
   }
@@ -1259,6 +1249,35 @@ void NotEqual_Test(const T& precision) {
   EXPECT_TRUE(expected != close);
 }
 TEST_ALL_F(NotEqual, FLOAT_PRECISION, DOUBLE_PRECISION)
+
+// Test that operator== and operator!= correctly detect differences in each
+// individual element of the matrix. This verifies that the inequality check
+// uses logical OR (short-circuit) rather than bitwise OR, and that every
+// element position is properly compared.
+template <class T, int d>
+void EqualityPerElement_Test(const T& precision) {
+  (void)precision;
+  mathfu::Matrix<T, d> base;
+  for (int i = 0; i < d * d; ++i) {
+    base[i] = static_cast<T>(i + 1);
+  }
+
+  // A copy should be equal.
+  mathfu::Matrix<T, d> copy(base);
+  EXPECT_TRUE(base == copy);
+  EXPECT_FALSE(base != copy);
+
+  // Changing any single element should make the matrices not equal.
+  for (int i = 0; i < d * d; ++i) {
+    mathfu::Matrix<T, d> modified(base);
+    modified[i] = base[i] + static_cast<T>(100);
+    EXPECT_FALSE(base == modified)
+        << "Element " << i << " difference not detected by operator==";
+    EXPECT_TRUE(base != modified)
+        << "Element " << i << " difference not detected by operator!=";
+  }
+}
+TEST_ALL_F(EqualityPerElement, FLOAT_PRECISION, DOUBLE_PRECISION)
 
 // Simple class that represents a possible compatible type for a vector.
 // That is, it's just an array of T of length d, so can be loaded and


### PR DESCRIPTION
MathfuMatrixUnroller::NotEqual used | (bitwise OR) to combine element comparisons instead of || (logical OR). While the result was technically correct, this prevented short-circuit evaluation and was clearly unintended. Changed to || so that inequality checks can exit early once a difference is found.

Added EqualityPerElement test that verifies operator== and operator!= correctly detect differences at every individual element position.