### PR TITLE
Replace union type-punning with memcpy in FromType/ToType helpers

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -19,6 +19,7 @@
 #include <assert.h>
 
 #include <cmath>
+#include <cstring>
 
 #include "mathfu/utilities.h"
 #include "mathfu/vector.h"
@@ -1534,60 +1535,30 @@ static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
 template <typename T, int Rows, int Cols, typename CompatibleT>
 static inline Matrix<T, Rows, Cols> FromTypeHelper(
     const CompatibleT& compatible) {
-// C++11 is required for constructed unions.
-#if __cplusplus >= 201103L
-  // Use a union instead of reinterpret_cast to avoid aliasing bugs.
-  union ConversionUnion {
-    ConversionUnion() {}  // C++11.
-    CompatibleT compatible;
-    VectorPacked<T, Rows> packed[Cols];
-  } u;
-  static_assert(sizeof(u.compatible) == sizeof(u.packed),
+  // Use memcpy to safely reinterpret between compatible types without
+  // undefined behavior. The compiler will optimize memcpy of small types
+  // into simple register moves.
+  VectorPacked<T, Rows> packed[Cols];
+  static_assert(sizeof(compatible) == sizeof(packed),
                 "Conversion size mismatch.");
-
-  // The read of `compatible` and write to `u.compatible` gets optimized away,
-  // and this becomes essentially a safe reinterpret_cast.
-  u.compatible = compatible;
-
-  // Call the packed vector constructor with the `compatible` data.
-  return Matrix<T, Rows, Cols>(u.packed);
-#else
-  // Use the less-desirable memcpy technique if C++11 is not available.
-  // Most compilers understand memcpy deep enough to avoid replace the function
-  // call with a series of load/stores, which should then get optimized away,
-  // however in the worst case the optimize away may not happen.
-  // Note: Memcpy avoids aliasing bugs because it operates via unsigned char*,
-  // which is allowed to alias any type.
-  // See:
-  // http://stackoverflow.com/questions/15745030/type-punning-with-void-without-breaking-the-strict-aliasing-rule-in-c99
-  Matrix<T, Rows, Cols> m;
-  assert(sizeof(m) == sizeof(compatible));
-  memcpy(&m, &compatible, sizeof(m));
-  return m;
-#endif  // __cplusplus >= 201103L
+  std::memcpy(packed, &compatible, sizeof(packed));
+  return Matrix<T, Rows, Cols>(packed);
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 template <typename T, int Rows, int Cols, typename CompatibleT>
 static inline CompatibleT ToTypeHelper(const Matrix<T, Rows, Cols>& m) {
-// See FromTypeHelper() for comments.
-#if __cplusplus >= 201103L
-  union ConversionUnion {
-    ConversionUnion() {}
-    CompatibleT compatible;
-    VectorPacked<T, Rows> packed[Cols];
-  } u;
-  static_assert(sizeof(u.compatible) == sizeof(u.packed),
+  // Use memcpy to safely reinterpret between compatible types without
+  // undefined behavior. The compiler will optimize memcpy of small types
+  // into simple register moves.
+  VectorPacked<T, Rows> packed[Cols];
+  static_assert(sizeof(CompatibleT) == sizeof(packed),
                 "Conversion size mismatch.");
-  m.Pack(u.packed);
-  return u.compatible;
-#else
+  m.Pack(packed);
   CompatibleT compatible;
-  assert(sizeof(m) == sizeof(compatible));
-  memcpy(&compatible, &m, sizeof(compatible));
+  std::memcpy(&compatible, packed, sizeof(packed));
   return compatible;
-#endif  // __cplusplus >= 201103L
 }
 /// @endcond
 

--- a/include/mathfu/vector.h
+++ b/include/mathfu/vector.h
@@ -19,6 +19,7 @@
 #include <math.h>
 
 #include <cmath>
+#include <cstring>
 
 #include "mathfu/utilities.h"
 
@@ -1014,60 +1015,30 @@ static inline T DotProductHelper(const Vector<T, 4>& v1,
 /// @cond MATHFU_INTERNAL
 template <typename T, int Dims, typename CompatibleT>
 static inline Vector<T, Dims> FromTypeHelper(const CompatibleT& compatible) {
-// C++11 is required for constructed unions.
-#if __cplusplus >= 201103L
-  // Use a union instead of reinterpret_cast to avoid aliasing bugs.
-  union ConversionUnion {
-    ConversionUnion() {}  // C++11.
-    CompatibleT compatible;
-    VectorPacked<T, Dims> packed;
-  } u;
-  static_assert(sizeof(u.compatible) == Dims * sizeof(T),
+  // Use memcpy to safely reinterpret between compatible types without
+  // undefined behavior. The compiler will optimize memcpy of small types
+  // into simple register moves.
+  VectorPacked<T, Dims> packed;
+  static_assert(sizeof(compatible) == sizeof(packed),
                 "Conversion size mismatch.");
-
-  // The read of `compatible` and write to `u.compatible` gets optimized away,
-  // and this becomes essentially a safe reinterpret_cast.
-  u.compatible = compatible;
-
-  // Call the packed vector constructor with the `compatible` data.
-  return Vector<T, Dims>(u.packed);
-#else
-  // Use the less-desirable memcpy technique if C++11 is not available.
-  // Most compilers understand memcpy deep enough to avoid replace the function
-  // call with a series of load/stores, which should then get optimized away,
-  // however in the worst case the optimize away may not happen.
-  // Note: Memcpy avoids aliasing bugs because it operates via unsigned char*,
-  // which is allowed to alias any type.
-  // See:
-  // http://stackoverflow.com/questions/15745030/type-punning-with-void-without-breaking-the-strict-aliasing-rule-in-c99
-  Vector<T, Dims> v;
-  assert(sizeof(compatible) == Dims * sizeof(T));
-  memcpy(&v, &compatible, sizeof(compatible));
-  return v;
-#endif  // __cplusplus >= 201103L
+  std::memcpy(&packed, &compatible, sizeof(packed));
+  return Vector<T, Dims>(packed);
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 template <typename T, int Dims, typename CompatibleT>
 static inline CompatibleT ToTypeHelper(const Vector<T, Dims>& v) {
-// See FromTypeHelper() for comments.
-#if __cplusplus >= 201103L
-  union ConversionUnion {
-    ConversionUnion() {}
-    CompatibleT compatible;
-    VectorPacked<T, Dims> packed;
-  } u;
-  static_assert(sizeof(u.compatible) == Dims * sizeof(T),
+  // Use memcpy to safely reinterpret between compatible types without
+  // undefined behavior. The compiler will optimize memcpy of small types
+  // into simple register moves.
+  VectorPacked<T, Dims> packed;
+  static_assert(sizeof(CompatibleT) == sizeof(packed),
                 "Conversion size mismatch.");
-  v.Pack(&u.packed);
-  return u.compatible;
-#else
+  v.Pack(&packed);
   CompatibleT compatible;
-  assert(sizeof(compatible) == Dims * sizeof(T));
-  memcpy(&compatible, &v, sizeof(compatible));
+  std::memcpy(&compatible, &packed, sizeof(packed));
   return compatible;
-#endif  // __cplusplus >= 201103L
 }
 /// @endcond
 

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -1343,6 +1343,39 @@ void ToType_Test(const T& precision) {
 }
 TEST_ALL_F(ToType, 0.0f, 0.0)
 
+// This will test a roundtrip through FromType() and ToType().
+// Converts SimpleMatrix -> Matrix -> SimpleMatrix and verifies the values
+// are preserved. This exercises the memcpy-based type-punning path.
+template <class T, int d>
+void FromTypeToTypeRoundtrip_Test(const T& precision) {
+  typedef SimpleMatrix<T, d> CompatibleT;
+  typedef mathfu::Matrix<T, d> MatrixT;
+
+  CompatibleT original;
+  for (int i = 0; i < d * d; ++i) {
+    original.values[i] = static_cast<T>(i * precision + static_cast<T>(1));
+  }
+
+#ifdef MATHFU_COMPILE_WITH_PADDING
+  // With padding, vec3s take up 4-floats worth of memory, so byte-wise
+  // conversion won't work.
+  if (sizeof(CompatibleT) != sizeof(MatrixT)) {
+    EXPECT_EQ(d, 3);
+    return;
+  }
+#endif  // MATHFU_COMPILE_WITH_PADDING
+
+  // SimpleMatrix -> Matrix -> SimpleMatrix
+  const MatrixT matrix = MatrixT::FromType(original);
+  const CompatibleT roundtripped =
+      MatrixT::template ToType<CompatibleT>(matrix);
+
+  for (int i = 0; i < d * d; ++i) {
+    EXPECT_EQ(original.values[i], roundtripped.values[i]);
+  }
+}
+TEST_ALL_F(FromTypeToTypeRoundtrip, 0.0f, 0.0)
+
 template <class T, int d>
 void OutputStream_Test(const T&) {
   mathfu::Matrix<T, d> matrix;

--- a/unit_tests/vector_test/vector_test.cpp
+++ b/unit_tests/vector_test/vector_test.cpp
@@ -978,6 +978,31 @@ void ToType_Test(const T& precision) {
 TEST_ALL_F(ToType)
 TEST_ALL_INTS_F(ToType)
 
+// This will test a roundtrip through FromType() and ToType().
+// Converts SimpleVector -> Vector -> SimpleVector and verifies the values
+// are preserved. This exercises the memcpy-based type-punning path.
+template <class T, int d>
+void FromTypeToTypeRoundtrip_Test(const T& precision) {
+  typedef SimpleVector<T, d> CompatibleT;
+  typedef mathfu::Vector<T, d> VectorT;
+
+  CompatibleT original;
+  for (int i = 0; i < d; ++i) {
+    original.values[i] = static_cast<T>(i * precision + static_cast<T>(1));
+  }
+
+  // SimpleVector -> Vector -> SimpleVector
+  const VectorT vector = VectorT::FromType(original);
+  const CompatibleT roundtripped =
+      VectorT::template ToType<CompatibleT>(vector);
+
+  for (int i = 0; i < d; ++i) {
+    EXPECT_EQ(original.values[i], roundtripped.values[i]);
+  }
+}
+TEST_ALL_F(FromTypeToTypeRoundtrip)
+TEST_ALL_INTS_F(FromTypeToTypeRoundtrip)
+
 // Test output stream operator.
 template <class T, int d>
 void OutputStream_Test(const T&) {


### PR DESCRIPTION
The FromTypeHelper and ToTypeHelper functions in vector.h and matrix.h used a union to reinterpret between compatible types. In C++, reading a union member that wasn't the most recently written is undefined behavior.

Replace the union approach with std::memcpy, which is the standard-compliant way to do type-punning in C++. The compiler optimizes memcpy of small types into simple register moves, so there is no performance cost.

Also remove the #if __cplusplus >= 201103L pre-C++11 fallback branches since the library targets C++14+, and add roundtrip tests for both vector and matrix FromType/ToType conversions.