### PR TITLE
Document that default constructors leave members uninitialized

### DIFF
--- a/include/mathfu/internal/vector_2_simd.h
+++ b/include/mathfu/internal/vector_2_simd.h
@@ -40,6 +40,11 @@ class Vector<float, 2> {
   typedef float Scalar;
   static const int kDims = 2;
 
+  /// @brief Create an uninitialized Vector.
+  ///
+  /// The elements of the Vector are left uninitialized and have indeterminate
+  /// values. This is intentional for performance: use Vector(float) or the
+  /// component constructor if you need specific values.
   inline Vector() {}
 
   inline Vector(const Vector<float, 2>& v) { simd2 = v.simd2; }

--- a/include/mathfu/internal/vector_3_simd.h
+++ b/include/mathfu/internal/vector_3_simd.h
@@ -74,6 +74,11 @@ class Vector<float, 3> {
   typedef float Scalar;
   static const int kDims = 3;
 
+  /// @brief Create an uninitialized Vector.
+  ///
+  /// The elements of the Vector are left uninitialized and have indeterminate
+  /// values. This is intentional for performance: use Vector(float) or the
+  /// component constructor if you need specific values.
   inline Vector() {}
 
   inline Vector(const Vector<float, 3>& v) {

--- a/include/mathfu/internal/vector_4_simd.h
+++ b/include/mathfu/internal/vector_4_simd.h
@@ -40,6 +40,11 @@ class Vector<float, 4> {
   typedef float Scalar;
   static const int kDims = 4;
 
+  /// @brief Create an uninitialized Vector.
+  ///
+  /// The elements of the Vector are left uninitialized and have indeterminate
+  /// values. This is intentional for performance: use Vector(float) or the
+  /// component constructor if you need specific values.
   inline Vector() {}
 
   inline Vector(const Vector<float, 4>& v) { simd4 = v.simd4; }

--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -185,6 +185,10 @@ template <class T, int Rows, int Cols>
 class Matrix {
  public:
   /// @brief Construct a Matrix of uninitialized values.
+  ///
+  /// The elements of the Matrix are left uninitialized and have indeterminate
+  /// values. This is intentional for performance: use Matrix(T), Identity(),
+  /// or one of the factory methods if you need specific values.
   inline Matrix() {}
 
   /// @brief Construct a Matrix from another Matrix copying each element.

--- a/include/mathfu/quaternion.h
+++ b/include/mathfu/quaternion.h
@@ -47,6 +47,11 @@ template <class T>
 class Quaternion {
  public:
   /// @brief Construct an uninitialized Quaternion.
+  ///
+  /// The scalar and vector components of the Quaternion are left uninitialized
+  /// and have indeterminate values. This is intentional for performance: use
+  /// Quaternion(T, T, T, T) or Quaternion::identity if you need specific
+  /// values.
   inline Quaternion() {}
 
   /// @brief Construct a Quaternion from a copy.

--- a/include/mathfu/vector.h
+++ b/include/mathfu/vector.h
@@ -123,7 +123,12 @@ static inline CompatibleT ToTypeHelper(const Vector<T, Dims>& v);
 /// @tparam Dims dimensions (number of elements) in the VectorPacked structure.
 template <class T, int Dims>
 struct VectorPacked {
-  /// Create an uninitialized VectorPacked.
+  /// @brief Create an uninitialized VectorPacked.
+  ///
+  /// The elements of the VectorPacked are left uninitialized and have
+  /// indeterminate values. This is intentional for performance: use
+  /// VectorPacked(const Vector&) or aggregate initialization if you need
+  /// specific values.
   VectorPacked() {}
 
   /// Create a VectorPacked from a Vector.
@@ -187,6 +192,10 @@ class Vector {
   static const int kDims = Dims;
 
   /// @brief Create an uninitialized Vector.
+  ///
+  /// The elements of the Vector are left uninitialized and have indeterminate
+  /// values. This is intentional for performance: use Vector(T) or one of the
+  /// component constructors if you need specific values.
   inline Vector() {}
 
   /// @brief Create a vector from another vector copying each element.


### PR DESCRIPTION
Add documentation comments to the default constructors of Vector, VectorPacked, Matrix, and Quaternion explaining that members are intentionally left uninitialized for performance and pointing users to alternative constructors when specific values are needed. This also covers the SIMD-specialized Vector<float, 2/3/4> variants.