### PR TITLE
Fix RoundUpToPowerOf2 for non-int32 types and edge cases

### DIFF
--- a/include/mathfu/utilities.h
+++ b/include/mathfu/utilities.h
@@ -22,7 +22,9 @@
 #include <stdlib.h>
 
 #include <algorithm>
+#include <climits>
 #include <memory>
+#include <type_traits>
 
 /// @file mathfu/utilities.h Utilities
 /// @brief Utility macros and functions.
@@ -427,27 +429,53 @@ inline int RandomInRange<int>(int range_start, int range_end) {
 }
 /// @endcond
 
-/// @brief Round a value up to the nearest power of 2.
+/// @brief Round a value up to the nearest power of 2 (integer overload).
 ///
-/// @param x Value to round up.
+/// For integer types, uses bit manipulation that works correctly for any
+/// integer width (8, 16, 32, 64-bit, etc.).
+///
+/// @note If @p x is 0, the return value is 0.
+/// @note If @p x is already a power of 2, it is returned unchanged.
+/// @note If the result would overflow the type (i.e. @p x is greater than
+///       the largest power of 2 representable by T), the behavior is
+///       undefined due to unsigned overflow wrapping to 0.
+///
+/// @param x Value to round up. Must be non-negative for signed types.
 /// @returns Value rounded up to the nearest power of 2.
 template <class T>
-T RoundUpToPowerOf2(T x) {
-  return static_cast<T>(
-      pow(static_cast<T>(2), ceil(log(x) / log(static_cast<T>(2)))));
+typename std::enable_if<std::is_integral<T>::value, T>::type RoundUpToPowerOf2(
+    T x) {
+  // Use unsigned arithmetic to avoid undefined behavior with signed shifts.
+  typedef typename std::make_unsigned<T>::type U;
+  if (x <= 1) return x;
+  U u = static_cast<U>(x - 1);
+  // Smear the highest set bit down to all lower bits. Each shift doubles the
+  // range of bits that are set, so we need log2(bit_width) iterations.
+  // We iterate over all possible shift amounts; for types smaller than the
+  // shift, the compiler will optimize away the redundant operations.
+  for (unsigned shift = 1; shift < sizeof(T) * CHAR_BIT; shift <<= 1) {
+    u |= u >> shift;
+  }
+  return static_cast<T>(u + 1);
 }
 
-/// @brief Specialized version of RoundUpToPowerOf2 for int32_t.
-template <>
-inline int32_t RoundUpToPowerOf2<>(int32_t x) {
-  x--;
-  x |= x >> 1;
-  x |= x >> 2;
-  x |= x >> 4;
-  x |= x >> 8;
-  x |= x >> 16;
-  x++;
-  return x;
+/// @brief Round a value up to the nearest power of 2 (floating-point
+/// overload).
+///
+/// For floating-point types, uses logarithmic computation.
+///
+/// @note If @p x is 0, the return value is 0.
+/// @note Results may be imprecise for very large floating-point values due
+///       to floating-point arithmetic limitations.
+///
+/// @param x Value to round up. Must be non-negative.
+/// @returns Value rounded up to the nearest power of 2.
+template <class T>
+typename std::enable_if<std::is_floating_point<T>::value, T>::type
+RoundUpToPowerOf2(T x) {
+  if (x <= 0) return x;
+  return static_cast<T>(
+      pow(static_cast<T>(2), ceil(log(x) / log(static_cast<T>(2)))));
 }
 
 /// @brief Round a value up to the type's alignment boundary.

--- a/unit_tests/vector_test/vector_test.cpp
+++ b/unit_tests/vector_test/vector_test.cpp
@@ -15,12 +15,15 @@
  */
 #include "mathfu/vector.h"
 
+#include <climits>
+#include <cstdint>
 #include <sstream>
 #include <string>
 
 #include "gtest/gtest.h"
 #include "mathfu/constants.h"
 #include "mathfu/io.h"
+#include "mathfu/utilities.h"
 #include "precision.h"
 
 class VectorTests : public ::testing::Test {
@@ -790,6 +793,147 @@ TEST_F(VectorTests, Angle_AntiParallelDoesNotReturnNaN) {
   angle = Vec3::Angle(a, b);
   EXPECT_FALSE(std::isnan(angle));
   EXPECT_NEAR(angle, 0.0f, FLOAT_PRECISION);
+}
+
+// Tests scalar RoundUpToPowerOf2 for int32_t.
+TEST_F(VectorTests, RoundUpToPowerOf2_Int32) {
+  // Zero returns zero.
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(0)), 0);
+
+  // One returns one (already a power of 2).
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(1)), 1);
+
+  // Powers of 2 remain unchanged.
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(2)), 2);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(4)), 4);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(64)), 64);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(1024)), 1024);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(1 << 30)),
+            (1 << 30));
+
+  // Non-powers of 2 round up.
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(3)), 4);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(5)), 8);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(6)), 8);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(7)), 8);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(9)), 16);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(100)), 128);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(1000)), 1024);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int32_t>(1025)), 2048);
+}
+
+// Tests scalar RoundUpToPowerOf2 for uint32_t.
+TEST_F(VectorTests, RoundUpToPowerOf2_Uint32) {
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint32_t>(0)),
+            static_cast<uint32_t>(0));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint32_t>(1)),
+            static_cast<uint32_t>(1));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint32_t>(2)),
+            static_cast<uint32_t>(2));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint32_t>(3)),
+            static_cast<uint32_t>(4));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint32_t>(5)),
+            static_cast<uint32_t>(8));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint32_t>(255)),
+            static_cast<uint32_t>(256));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint32_t>(1u << 31)),
+            static_cast<uint32_t>(1u << 31));
+}
+
+// Tests scalar RoundUpToPowerOf2 for int64_t.
+TEST_F(VectorTests, RoundUpToPowerOf2_Int64) {
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int64_t>(0)),
+            static_cast<int64_t>(0));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int64_t>(1)),
+            static_cast<int64_t>(1));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int64_t>(2)),
+            static_cast<int64_t>(2));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int64_t>(3)),
+            static_cast<int64_t>(4));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int64_t>(5)),
+            static_cast<int64_t>(8));
+
+  // Test values beyond 32-bit range.
+  int64_t large = static_cast<int64_t>(1) << 32;
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(large), large);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(large + 1), large * 2);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(large - 1), large);
+
+  int64_t very_large = static_cast<int64_t>(1) << 62;
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(very_large), very_large);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(very_large - 1), very_large);
+}
+
+// Tests scalar RoundUpToPowerOf2 for uint64_t.
+TEST_F(VectorTests, RoundUpToPowerOf2_Uint64) {
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint64_t>(0)),
+            static_cast<uint64_t>(0));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint64_t>(1)),
+            static_cast<uint64_t>(1));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint64_t>(3)),
+            static_cast<uint64_t>(4));
+
+  // Test values beyond 32-bit range.
+  uint64_t large = static_cast<uint64_t>(1) << 32;
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(large), large);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(large + 1), large * 2);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(large - 1), large);
+
+  uint64_t very_large = static_cast<uint64_t>(1) << 63;
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(very_large), very_large);
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(very_large - 1), very_large);
+}
+
+// Tests scalar RoundUpToPowerOf2 for int16_t.
+TEST_F(VectorTests, RoundUpToPowerOf2_Int16) {
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int16_t>(0)),
+            static_cast<int16_t>(0));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int16_t>(1)),
+            static_cast<int16_t>(1));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int16_t>(3)),
+            static_cast<int16_t>(4));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int16_t>(255)),
+            static_cast<int16_t>(256));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<int16_t>(1 << 14)),
+            static_cast<int16_t>(1 << 14));
+}
+
+// Tests scalar RoundUpToPowerOf2 for uint8_t.
+TEST_F(VectorTests, RoundUpToPowerOf2_Uint8) {
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint8_t>(0)),
+            static_cast<uint8_t>(0));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint8_t>(1)),
+            static_cast<uint8_t>(1));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint8_t>(2)),
+            static_cast<uint8_t>(2));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint8_t>(3)),
+            static_cast<uint8_t>(4));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint8_t>(127)),
+            static_cast<uint8_t>(128));
+  EXPECT_EQ(mathfu::RoundUpToPowerOf2(static_cast<uint8_t>(128)),
+            static_cast<uint8_t>(128));
+}
+
+// Tests scalar RoundUpToPowerOf2 for all int values from 0 to 1024.
+TEST_F(VectorTests, RoundUpToPowerOf2_Exhaustive_Int32) {
+  int32_t expected = 0;
+  for (int32_t i = 0; i <= 1024; ++i) {
+    // Compute expected: smallest power of 2 >= i (with 0 mapping to 0).
+    if (i == 0) {
+      expected = 0;
+    } else if (i == 1) {
+      expected = 1;
+    } else if ((i & (i - 1)) == 0) {
+      // i is already a power of 2.
+      expected = i;
+    } else {
+      // Find next power of 2.
+      expected = 1;
+      while (expected < i) expected <<= 1;
+    }
+    EXPECT_EQ(mathfu::RoundUpToPowerOf2(i), expected)
+        << "Failed for input " << i;
+  }
 }
 
 // Tests the RoundUpToPowerOf2 function for vectors.


### PR DESCRIPTION
Replace the old implementation which had a generic template using floating-point log/pow (imprecise, undefined for 0) and a single int32_t specialization (didn't cover uint32_t, int64_t, uint64_t, int16_t, uint8_t, etc.).

The new implementation uses SFINAE to provide:
- An integer overload using bit-smearing that works for any integer width (8, 16, 32, 64-bit, signed or unsigned). The loop iterates over shift amounts 1, 2, 4, 8, 16, 32 as needed based on sizeof(T).
- A floating-point overload that preserves the original log/pow approach but adds a guard for x <= 0.

Edge cases are now handled correctly:
- Input 0 returns 0
- Input 1 returns 1
- Powers of 2 are returned unchanged
- Preconditions are documented in doxygen comments

Added comprehensive scalar tests covering int32_t, uint32_t, int64_t, uint64_t, int16_t, uint8_t, and an exhaustive 0-1024 sweep.