### PR TITLE
Propagate inverse failure status from Matrix::UnProject

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -868,16 +868,19 @@ class Matrix {
   /// @param projection The projection matrix.
   /// @param window_width Width of the window.
   /// @param window_height Height of the window.
-  /// @return the mapped 3D position in object space.
-  static inline Vector<T, 3> UnProject(const Vector<T, 3>& window_coord,
-                                       const Matrix<T, 4, 4>& model_view,
-                                       const Matrix<T, 4, 4>& projection,
-                                       const float window_width,
-                                       const float window_height) {
-    Vector<T, 3> result;
-    UnProjectHelper(window_coord, model_view, projection, window_width,
-                    window_height, result);
-    return result;
+  /// @param result Output: the mapped 3D position in object space.
+  /// @return Whether the unprojection succeeded. This can fail if the
+  /// model-view-projection matrix is singular (not invertible), or if
+  /// the homogeneous coordinate w is zero, or if the window_coord z
+  /// value is outside the [0, 1] range.
+  static inline bool UnProject(const Vector<T, 3>& window_coord,
+                               const Matrix<T, 4, 4>& model_view,
+                               const Matrix<T, 4, 4>& projection,
+                               const float window_width,
+                               const float window_height,
+                               Vector<T, 3>* result) {
+    return UnProjectHelper(window_coord, model_view, projection, window_width,
+                           window_height, *result);
   }
 
   /// @brief Multiply a Vector by a Matrix.
@@ -1512,7 +1515,11 @@ static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
     // 1: far plane
     return false;
   }
-  Matrix<T, 4, 4> matrix = (projection * model_view).Inverse();
+  Matrix<T, 4, 4> mvp = projection * model_view;
+  Matrix<T, 4, 4> matrix;
+  if (!mvp.InverseWithDeterminantCheck(&matrix)) {
+    return false;
+  }
   Vector<T, 4> standardized = Vector<T, 4>(
       static_cast<T>(2) * (window_coord.x - window_width) / window_width
           + static_cast<T>(1),

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -838,13 +838,37 @@ void UnProject_Test(const T& precision) {
                         0,          0,   static_cast<T>(-1.00001991), -1,
                         0,          0,  static_cast<T>(-0.200001985),  0);
   // clang-format on
-  mathfu::Vector<T, 3> result = mathfu::Matrix<T, 4, 4>::UnProject(
-      mathfu::Vector<T, 3>(754, 1049, 1), modelView, projection, 1600, 1200);
+  mathfu::Vector<T, 3> result;
+  bool success = mathfu::Matrix<T, 4, 4>::UnProject(
+      mathfu::Vector<T, 3>(754, 1049, 1), modelView, projection, 1600, 1200,
+      &result);
+  EXPECT_TRUE(success);
   EXPECT_NEAR(result.x, 319.00242400912055, 300.0 * precision);
   EXPECT_NEAR(result.y, 3113.7409399625253, 3000.0 * precision);
   EXPECT_NEAR(result.z, 10035.303114023569, 10000.0 * precision);
 }
 TEST_SCALAR_F(UnProject, kUnProjectFloatPrecision, DOUBLE_PRECISION)
+
+// Test UnProject returns false for a singular (all-zero) matrix.
+template <class T>
+void UnProject_SingularMatrix_Test(const T& precision) {
+  (void)precision;
+  // A zero matrix is singular and cannot be inverted.
+  mathfu::Matrix<T, 4, 4> singular =
+      mathfu::Matrix<T, 4, 4>(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+  mathfu::Matrix<T, 4, 4> identity = mathfu::Matrix<T, 4, 4>::Identity();
+  mathfu::Vector<T, 3> window_coord(400, 300, static_cast<T>(0.5));
+  mathfu::Vector<T, 3> result;
+  // Singular model-view matrix.
+  bool success_mv = mathfu::Matrix<T, 4, 4>::UnProject(
+      window_coord, singular, identity, 800, 600, &result);
+  EXPECT_FALSE(success_mv);
+  // Singular projection matrix.
+  bool success_proj = mathfu::Matrix<T, 4, 4>::UnProject(
+      window_coord, identity, singular, 800, 600, &result);
+  EXPECT_FALSE(success_proj);
+}
+TEST_SCALAR_F(UnProject_SingularMatrix, FLOAT_PRECISION, DOUBLE_PRECISION)
 
 // Test matrix transposition.
 template <class T, int d>


### PR DESCRIPTION
UnProjectHelper was calling Inverse() which silently ignores singular matrices and produces garbage output. Changed to use InverseWithDeterminantCheck() so that singular MVP matrices are properly detected and reported as failures.

Also changed the public UnProject API to return bool with the result passed through an output pointer, making it impossible for callers to silently ignore the failure status.