### PR TITLE
Make handedness defaults consistent (right-handed) across all functions

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -837,11 +837,10 @@ class Matrix {
   /// y-axis is up.
   /// @param handedness 1.0f for RH, -1.0f for LH.
   /// @return 3-dimensional camera Matrix.
-  /// TODO: Change default handedness to +1 so that it matches Perspective().
   static inline Matrix<T, 4, 4> LookAt(const Vector<T, 3>& at,
                                        const Vector<T, 3>& eye,
                                        const Vector<T, 3>& up,
-                                       T handedness = -1) {
+                                       T handedness = 1) {
     return LookAtHelper(at, eye, up, handedness);
   }
 

--- a/include/mathfu/quaternion.h
+++ b/include/mathfu/quaternion.h
@@ -605,6 +605,7 @@ class Quaternion {
   ///
   /// @param forward The forward vector (Vector to face).
   /// @param up The up vector.
+  /// @param handedness 1.0f for RH, -1.0f for LH.
   /// @param Forward and up do not have to be orthogonal.
   /// @param Forward and up cannot be parallel.
   /// @param Forward and up cannot be zero vectors.
@@ -616,9 +617,9 @@ class Quaternion {
   /// The params can be represented with zero-vector as source and
   /// forward-vector as destination.
   static inline Quaternion<T> LookAt(const Vector<T, 3>& forward,
-                                     const Vector<T, 3>& up) {
-    return FromMatrix(
-        Matrix<T, 3>::LookAt(forward, Vector<T, 3>(static_cast<T>(0)), up));
+                                     const Vector<T, 3>& up, T handedness = 1) {
+    return FromMatrix(Matrix<T, 3>::LookAt(
+        forward, Vector<T, 3>(static_cast<T>(0)), up, handedness));
   }
 
   /// @brief Contains a quaternion doing the identity transform.

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -700,10 +700,20 @@ void LookAt_Test(const T& precision) {
   // clang-format off
   static const MatrixExpectation<T, 4, 4> kTestCases[] = {
     {
-      "origin along z",
+      "default RH origin along z",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 0, 1), mathfu::Vector<T, 3>(0, 0, 0),
           mathfu::Vector<T, 3>(0, 1, 0)),
+      mathfu::Matrix<T, 4, 4>(-1, 0, 0, 0,
+                               0, 1, 0, 0,
+                               0, 0, -1,0,
+                               0, 0, 0, 1),
+    },
+    {
+      "left-handed origin along z",
+      mathfu::Matrix<T, 4, 4>::LookAt(
+          mathfu::Vector<T, 3>(0, 0, 1), mathfu::Vector<T, 3>(0, 0, 0),
+          mathfu::Vector<T, 3>(0, 1, 0), -1),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,

--- a/unit_tests/quaternion_test/quaternion_test.cpp
+++ b/unit_tests/quaternion_test/quaternion_test.cpp
@@ -631,10 +631,26 @@ template <class T>
 void LookAt_Test(const T& precision) {
   const T one = static_cast<T>(1);
   const T zero = static_cast<T>(0);
+  // Default (right-handed): looking along +z with up +y produces a 180-degree
+  // rotation around the y-axis.
+  EXPECT_NEAR_QUAT(
+      mathfu::Quaternion<T>(zero, zero, one, zero),
+      mathfu::Quaternion<T>::LookAt(mathfu::Vector<T, 3>(zero, zero, one),
+                                    mathfu::Vector<T, 3>(zero, one, zero)),
+      precision);
+  // Explicit right-handed should match the default.
+  EXPECT_NEAR_QUAT(
+      mathfu::Quaternion<T>::LookAt(mathfu::Vector<T, 3>(zero, zero, one),
+                                    mathfu::Vector<T, 3>(zero, one, zero)),
+      mathfu::Quaternion<T>::LookAt(mathfu::Vector<T, 3>(zero, zero, one),
+                                    mathfu::Vector<T, 3>(zero, one, zero), one),
+      precision);
+  // Explicit left-handed: looking along +z with up +y produces identity.
   EXPECT_NEAR_QUAT(
       mathfu::Quaternion<T>::identity,
       mathfu::Quaternion<T>::LookAt(mathfu::Vector<T, 3>(zero, zero, one),
-                                    mathfu::Vector<T, 3>(zero, one, zero)),
+                                    mathfu::Vector<T, 3>(zero, one, zero),
+                                    static_cast<T>(-1)),
       precision);
 }
 TEST_ALL_F(LookAt)


### PR DESCRIPTION
Change Matrix::LookAt default handedness from -1 (left-handed) to 1 (right-handed) to match Perspective() and Ortho(). Add a handedness parameter to Quaternion::LookAt with a default of 1 (right-handed). Remove the TODO comment that noted this inconsistency.