### PR TITLE
Fix perspective and ortho matrices for correct OpenGL NDC mapping

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -94,6 +94,15 @@
 
 namespace mathfu {
 
+/// @brief Specifies the depth range convention for projection matrices.
+///
+/// OpenGL maps z to [-1, 1] (signed normalized device coordinates).
+/// DirectX maps z to [0, 1] (unsigned normalized device coordinates).
+enum class DepthRange {
+  kOpenGL,  ///< z maps to [-1, 1] (OpenGL / Vulkan with VK_KHR_maintenance1)
+  kDirectX  ///< z maps to [0, 1] (DirectX / Metal / Vulkan default)
+};
+
 /// @cond MATHFU_INTERNAL
 template <class T, int Rows, int Cols = Rows>
 class Matrix;
@@ -111,10 +120,11 @@ static inline Matrix<T, Rows, Cols> OuterProductHelper(
     const Vector<T, Rows>& v1, const Vector<T, Cols>& v2);
 template <class T>
 inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
-                                         T handedness);
+                                         T handedness, DepthRange depth_range);
 template <class T>
 static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
-                                          T znear, T zfar, T handedness);
+                                          T znear, T zfar, T handedness,
+                                          DepthRange depth_range);
 template <class T>
 static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
                                            const Vector<T, 3>& eye,
@@ -808,10 +818,14 @@ class Matrix {
   /// @param znear Near plane location.
   /// @param zfar Far plane location.
   /// @param handedness 1.0f for RH, -1.0f for LH
+  /// @param depth_range DepthRange::kOpenGL for z in [-1,1] (default),
+  ///                    DepthRange::kDirectX for z in [0,1].
   /// @return 4x4 perspective Matrix.
-  static inline Matrix<T, 4, 4> Perspective(T fovy, T aspect, T znear, T zfar,
-                                            T handedness = 1) {
-    return PerspectiveHelper(fovy, aspect, znear, zfar, handedness);
+  static inline Matrix<T, 4, 4> Perspective(
+      T fovy, T aspect, T znear, T zfar, T handedness = 1,
+      DepthRange depth_range = DepthRange::kOpenGL) {
+    return PerspectiveHelper(fovy, aspect, znear, zfar, handedness,
+                             depth_range);
   }
 
   /// @brief Create a 4x4 orthographic Matrix.
@@ -823,10 +837,14 @@ class Matrix {
   /// @param znear Near plane location.
   /// @param zfar Far plane location.
   /// @param handedness 1.0f for RH, -1.0f for LH
+  /// @param depth_range DepthRange::kOpenGL for z in [-1,1] (default),
+  ///                    DepthRange::kDirectX for z in [0,1].
   /// @return 4x4 orthographic Matrix.
-  static inline Matrix<T, 4, 4> Ortho(T left, T right, T bottom, T top, T znear,
-                                      T zfar, T handedness = 1) {
-    return OrthoHelper(left, right, bottom, top, znear, zfar, handedness);
+  static inline Matrix<T, 4, 4> Ortho(
+      T left, T right, T bottom, T top, T znear, T zfar, T handedness = 1,
+      DepthRange depth_range = DepthRange::kOpenGL) {
+    return OrthoHelper(left, right, bottom, top, znear, zfar, handedness,
+                       depth_range);
   }
 
   /// @brief Create a 3-dimensional camera Matrix.
@@ -1405,31 +1423,66 @@ bool InverseHelper(const Matrix<T, 4, 4>& m, Matrix<T, 4, 4>* const inverse,
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
-/// Create a 4x4 perpective matrix.
+/// Create a 4x4 perspective matrix.
+///
+/// OpenGL convention (z maps to [-1, 1]):
+///   m[2][2] = (znear + zfar) / (znear - zfar)
+///   m[3][2] = (2 * znear * zfar) / (znear - zfar)
+///
+/// DirectX convention (z maps to [0, 1]):
+///   m[2][2] = zfar / (znear - zfar)
+///   m[3][2] = (znear * zfar) / (znear - zfar)
 template <class T>
 inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
-                                         T handedness) {
+                                         T handedness, DepthRange depth_range) {
   const T y = T(1) / std::tan(fovy * T(0.5));
   const T x = y / aspect;
   const T zdist = (znear - zfar);
-  const T zfar_per_zdist = zfar / zdist;
-  return Matrix<T, 4, 4>(x, 0, 0, 0, 0, y, 0, 0, 0, 0,
-                         zfar_per_zdist * handedness, T(-1) * handedness, 0, 0,
-                         T(2) * znear * zfar_per_zdist, 0);
+  T zz, zw;
+  if (depth_range == DepthRange::kOpenGL) {
+    // OpenGL: near plane -> z = -1, far plane -> z = 1
+    zz = (znear + zfar) / zdist;
+    zw = T(2) * znear * zfar / zdist;
+  } else {
+    // DirectX: near plane -> z = 0, far plane -> z = 1
+    zz = zfar / zdist;
+    zw = znear * zfar / zdist;
+  }
+  return Matrix<T, 4, 4>(x, 0, 0, 0, 0, y, 0, 0, 0, 0, zz * handedness,
+                         T(-1) * handedness, 0, 0, zw, 0);
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 /// Create a 4x4 orthographic matrix.
+///
+/// OpenGL convention (z maps to [-1, 1]):
+///   m[2][2] = -2 / (zfar - znear)
+///   m[3][2] = -(zfar + znear) / (zfar - znear)
+///
+/// DirectX convention (z maps to [0, 1]):
+///   m[2][2] = -1 / (zfar - znear)
+///   m[3][2] = -znear / (zfar - znear)
 template <class T>
 static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
-                                          T znear, T zfar, T handedness) {
+                                          T znear, T zfar, T handedness,
+                                          DepthRange depth_range) {
+  const T zdist = zfar - znear;
+  T zz, zw;
+  if (depth_range == DepthRange::kOpenGL) {
+    // OpenGL: near plane -> z = -1, far plane -> z = 1
+    zz = -handedness * static_cast<T>(2) / zdist;
+    zw = -(zfar + znear) / zdist;
+  } else {
+    // DirectX: near plane -> z = 0, far plane -> z = 1
+    zz = -handedness * static_cast<T>(1) / zdist;
+    zw = -znear / zdist;
+  }
   return Matrix<T, 4, 4>(static_cast<T>(2) / (right - left), 0, 0, 0, 0,
-                         static_cast<T>(2) / (top - bottom), 0, 0, 0, 0,
-                         -handedness * static_cast<T>(2) / (zfar - znear), 0,
+                         static_cast<T>(2) / (top - bottom), 0, 0, 0, 0, zz, 0,
                          -(right + left) / (right - left),
-                         -(top + bottom) / (top - bottom),
-                         -(zfar + znear) / (zfar - znear), static_cast<T>(1));
+                         -(top + bottom) / (top - bottom), zw,
+                         static_cast<T>(1));
 }
 /// @endcond
 

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -612,7 +612,7 @@ void Perspective_Test(const T& precision) {
           atan(static_cast<T>(1)) * 2, 1, -2, 2, 1),
       mathfu::Matrix<T, 4>(1, 0, 0, 0,
                            0, 1, 0, 0,
-                           0, 0, -0.5, -1,
+                           0, 0, 0, -1,
                            0, 0, 2, 0),
     },
   };
@@ -621,6 +621,81 @@ void Perspective_Test(const T& precision) {
       kTestCases, sizeof(kTestCases) / sizeof(kTestCases[0]), precision);
 }
 TEST_SCALAR_F(Perspective, FLOAT_PRECISION, DOUBLE_PRECISION * 10)
+
+// Test that the OpenGL perspective matrix maps the near plane to z = -1
+// and the far plane to z = 1.
+template <class T>
+void PerspectiveOpenGLDepth_Test(const T& precision) {
+  const T fovy = static_cast<T>(M_PI) / 4;  // 45 degrees
+  const T aspect = static_cast<T>(1.5);
+  const T znear = static_cast<T>(0.1);
+  const T zfar = static_cast<T>(100.0);
+  const T handedness = static_cast<T>(1);
+
+  mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Perspective(
+      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kOpenGL);
+
+  // Transform a point on the near plane (z = -znear in view space for RH).
+  mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
+  mathfu::Vector<T, 4> near_clip = proj * near_point;
+  T near_ndc_z = near_clip.z / near_clip.w;
+  EXPECT_NEAR(near_ndc_z, static_cast<T>(-1), precision);
+
+  // Transform a point on the far plane (z = -zfar in view space for RH).
+  mathfu::Vector<T, 4> far_point(0, 0, -zfar, 1);
+  mathfu::Vector<T, 4> far_clip = proj * far_point;
+  T far_ndc_z = far_clip.z / far_clip.w;
+  EXPECT_NEAR(far_ndc_z, static_cast<T>(1), precision);
+}
+TEST_SCALAR_F(PerspectiveOpenGLDepth, 1e-5f, 1e-10)
+
+// Test that the DirectX perspective matrix maps the near plane to z = 0
+// and the far plane to z = 1.
+template <class T>
+void PerspectiveDirectXDepth_Test(const T& precision) {
+  const T fovy = static_cast<T>(M_PI) / 4;  // 45 degrees
+  const T aspect = static_cast<T>(1.5);
+  const T znear = static_cast<T>(0.1);
+  const T zfar = static_cast<T>(100.0);
+  const T handedness = static_cast<T>(1);
+
+  mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Perspective(
+      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kDirectX);
+
+  // Transform a point on the near plane (z = -znear in view space for RH).
+  mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
+  mathfu::Vector<T, 4> near_clip = proj * near_point;
+  T near_ndc_z = near_clip.z / near_clip.w;
+  EXPECT_NEAR(near_ndc_z, static_cast<T>(0), precision);
+
+  // Transform a point on the far plane (z = -zfar in view space for RH).
+  mathfu::Vector<T, 4> far_point(0, 0, -zfar, 1);
+  mathfu::Vector<T, 4> far_clip = proj * far_point;
+  T far_ndc_z = far_clip.z / far_clip.w;
+  EXPECT_NEAR(far_ndc_z, static_cast<T>(1), precision);
+}
+TEST_SCALAR_F(PerspectiveDirectXDepth, 1e-5f, 1e-10)
+
+// Test that the default Perspective (no DepthRange argument) uses OpenGL
+// convention, matching the explicit OpenGL call.
+template <class T>
+void PerspectiveDefaultIsOpenGL_Test(const T& precision) {
+  const T fovy = static_cast<T>(M_PI) / 3;
+  const T aspect = static_cast<T>(1.6);
+  const T znear = static_cast<T>(1.0);
+  const T zfar = static_cast<T>(500.0);
+  const T handedness = static_cast<T>(1);
+
+  mathfu::Matrix<T, 4> default_proj =
+      mathfu::Matrix<T, 4>::Perspective(fovy, aspect, znear, zfar, handedness);
+  mathfu::Matrix<T, 4> opengl_proj = mathfu::Matrix<T, 4>::Perspective(
+      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kOpenGL);
+
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_NEAR(default_proj[i], opengl_proj[i], precision);
+  }
+}
+TEST_SCALAR_F(PerspectiveDefaultIsOpenGL, FLOAT_PRECISION, DOUBLE_PRECISION)
 
 // Test orthographic matrix calculation.
 template <class T>
@@ -693,6 +768,90 @@ void Ortho_Test(const T& precision) {
       kTestCases, sizeof(kTestCases) / sizeof(kTestCases[0]), precision);
 }
 TEST_SCALAR_F(Ortho, FLOAT_PRECISION, DOUBLE_PRECISION)
+
+// Test that the OpenGL orthographic matrix maps the near plane to z = -1
+// and the far plane to z = 1.
+template <class T>
+void OrthoOpenGLDepth_Test(const T& precision) {
+  const T left = static_cast<T>(-10);
+  const T right = static_cast<T>(10);
+  const T bottom = static_cast<T>(-10);
+  const T top = static_cast<T>(10);
+  const T znear = static_cast<T>(1);
+  const T zfar = static_cast<T>(100);
+  const T handedness = static_cast<T>(1);
+
+  mathfu::Matrix<T, 4> proj =
+      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
+                                  handedness, mathfu::DepthRange::kOpenGL);
+
+  // Transform a point on the near plane (z = -znear in view space for RH).
+  mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
+  mathfu::Vector<T, 4> near_clip = proj * near_point;
+  T near_ndc_z = near_clip.z / near_clip.w;
+  EXPECT_NEAR(near_ndc_z, static_cast<T>(-1), precision);
+
+  // Transform a point on the far plane (z = -zfar in view space for RH).
+  mathfu::Vector<T, 4> far_point(0, 0, -zfar, 1);
+  mathfu::Vector<T, 4> far_clip = proj * far_point;
+  T far_ndc_z = far_clip.z / far_clip.w;
+  EXPECT_NEAR(far_ndc_z, static_cast<T>(1), precision);
+}
+TEST_SCALAR_F(OrthoOpenGLDepth, 1e-5f, 1e-10)
+
+// Test that the DirectX orthographic matrix maps the near plane to z = 0
+// and the far plane to z = 1.
+template <class T>
+void OrthoDirectXDepth_Test(const T& precision) {
+  const T left = static_cast<T>(-10);
+  const T right = static_cast<T>(10);
+  const T bottom = static_cast<T>(-10);
+  const T top = static_cast<T>(10);
+  const T znear = static_cast<T>(1);
+  const T zfar = static_cast<T>(100);
+  const T handedness = static_cast<T>(1);
+
+  mathfu::Matrix<T, 4> proj =
+      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
+                                  handedness, mathfu::DepthRange::kDirectX);
+
+  // Transform a point on the near plane (z = -znear in view space for RH).
+  mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
+  mathfu::Vector<T, 4> near_clip = proj * near_point;
+  T near_ndc_z = near_clip.z / near_clip.w;
+  EXPECT_NEAR(near_ndc_z, static_cast<T>(0), precision);
+
+  // Transform a point on the far plane (z = -zfar in view space for RH).
+  mathfu::Vector<T, 4> far_point(0, 0, -zfar, 1);
+  mathfu::Vector<T, 4> far_clip = proj * far_point;
+  T far_ndc_z = far_clip.z / far_clip.w;
+  EXPECT_NEAR(far_ndc_z, static_cast<T>(1), precision);
+}
+TEST_SCALAR_F(OrthoDirectXDepth, 1e-5f, 1e-10)
+
+// Test that the default Ortho (no DepthRange argument) uses OpenGL convention,
+// matching the explicit OpenGL call.
+template <class T>
+void OrthoDefaultIsOpenGL_Test(const T& precision) {
+  const T left = static_cast<T>(-5);
+  const T right = static_cast<T>(5);
+  const T bottom = static_cast<T>(-5);
+  const T top = static_cast<T>(5);
+  const T znear = static_cast<T>(0.5);
+  const T zfar = static_cast<T>(200);
+  const T handedness = static_cast<T>(1);
+
+  mathfu::Matrix<T, 4> default_proj = mathfu::Matrix<T, 4>::Ortho(
+      left, right, bottom, top, znear, zfar, handedness);
+  mathfu::Matrix<T, 4> opengl_proj =
+      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
+                                  handedness, mathfu::DepthRange::kOpenGL);
+
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_NEAR(default_proj[i], opengl_proj[i], precision);
+  }
+}
+TEST_SCALAR_F(OrthoDefaultIsOpenGL, FLOAT_PRECISION, DOUBLE_PRECISION)
 
 // Test look-at matrix calculation.
 template <class T>


### PR DESCRIPTION
The PerspectiveHelper function previously used f/(n-f) for the z mapping, which corresponds to DirectX conventions (z in [0,1]) rather than the standard OpenGL convention (z in [-1,1]). This fixes the formula to use (n+f)/(n-f) for OpenGL and adds a DepthRange enum to let callers select between OpenGL and DirectX depth conventions for both Perspective and Ortho matrices.

Fixes #11, fixes #12.