### PR TITLE
Replace runtime assert with static_assert in InverseHelper

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -1272,9 +1272,12 @@ static inline Matrix<T, 4, 4> OuterProductHelper(const Vector<T, 4>& v1,
 template <bool check_invertible, class T, int Rows, int Cols>
 inline bool InverseHelper(const Matrix<T, Rows, Cols>& m,
                           Matrix<T, Rows, Cols>* const inverse, T det_thresh) {
-  assert(false);
+  static_assert(sizeof(T) == 0,
+                "Matrix::Inverse() is only implemented for "
+                "2x2, 3x3, and 4x4 matrices");
   (void)m;
-  *inverse = T::Identity();
+  (void)inverse;
+  (void)det_thresh;
   return false;
 }
 /// @endcond


### PR DESCRIPTION
## Summary

Replace the runtime `assert(false)` in the generic `InverseHelper` template with a `static_assert` that catches unsupported matrix sizes at compile time instead of runtime.

Closes #39

## Changes

- Replace `assert(false)` with `static_assert(sizeof(T) == 0, ...)` in the generic `InverseHelper` fallback template
- Use the `sizeof(T) == 0` pattern so the assertion only triggers when the template is actually instantiated, avoiding false positives in compilers that eagerly evaluate `static_assert` in uninstantiated templates
- Remove the unreachable `*inverse = T::Identity()` line and replace with `(void)` casts to suppress unused parameter warnings

## Testing

- The change is compile-time only; existing tests for 2x2, 3x3, and 4x4 inverse operations continue to work as before
- Attempting to call `Inverse()` on an unsupported matrix size (e.g., 5x5) will now produce a clear compile-time error instead of a runtime assertion failure