### PR TITLE
Format Matrix output to show column structure

### DIFF
--- a/include/mathfu/io.h
+++ b/include/mathfu/io.h
@@ -35,12 +35,16 @@ inline std::ostream& operator<<(std::ostream& os, const Vector<T, d>& v) {
 }
 
 /// @brief Print the matrix contents to the output stream.
+///
+/// Each column is printed as a vector, and all columns are grouped together.
+/// For example, a 3x3 identity matrix is printed as:
+/// ((1, 0, 0), (0, 1, 0), (0, 0, 1))
 template <typename T, int rows, int columns>
 inline std::ostream& operator<<(std::ostream& os,
                                 const Matrix<T, rows, columns>& m) {
-  os << "(" << m[0];
-  for (int i = 1; i < rows * columns; ++i) {
-    os << ", " << m[i];
+  os << "(" << m.GetColumn(0);
+  for (int i = 1; i < columns; ++i) {
+    os << ", " << m.GetColumn(i);
   }
   return os << ")";
 }

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -1581,17 +1581,18 @@ void OutputStream_Test(const T&) {
 
   switch (d) {
     case 1:
-      EXPECT_EQ("(0)", ss.str());
+      EXPECT_EQ("((0))", ss.str());
       break;
     case 2:
-      EXPECT_EQ("(0, 1, 2, 3)", ss.str());
+      EXPECT_EQ("((0, 1), (2, 3))", ss.str());
       break;
     case 3:
-      EXPECT_EQ("(0, 1, 2, 3, 4, 5, 6, 7, 8)", ss.str());
+      EXPECT_EQ("((0, 1, 2), (3, 4, 5), (6, 7, 8))", ss.str());
       break;
     case 4:
-      EXPECT_EQ("(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)",
-                ss.str());
+      EXPECT_EQ(
+          "((0, 1, 2, 3), (4, 5, 6, 7), (8, 9, 10, 11), (12, 13, 14, 15))",
+          ss.str());
       break;
   }
 }


### PR DESCRIPTION
## Summary
Matrix `operator<<` previously output elements as a flat comma-separated list identical to Vector format, making it impossible to visually distinguish a Matrix from a Vector in debug output.

Closes #76

## Changes
- Changed `operator<<` for `Matrix` in `io.h` to group elements by column using the existing `Vector` `operator<<`, producing output like `((1, 0, 0), (0, 1, 0), (0, 0, 1))` instead of `(1, 0, 0, 0, 1, 0, 0, 0, 1)`
- Updated expected strings in the `OutputStream_Test` matrix tests to match the new format

## Testing
- All matrix OutputStream tests updated and passing for all sizes (1x1, 2x2, 3x3, 4x4) with both float and double
- Full matrix test suite (201 tests) passes with no regressions