### PR TITLE
Extract shared cross/dot/normalize to vector.h, remove duplicates

### DIFF
--- a/include/mathfu/glsl_mappings.h
+++ b/include/mathfu/glsl_mappings.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_GLSL_MAPPINGS_H_
 #define MATHFU_GLSL_MAPPINGS_H_
 
@@ -82,35 +82,6 @@ typedef Rect<float> rectf;
 typedef Rect<double> rectd;
 /// Rect composed of type <code>int</code>.
 typedef Rect<int> recti;
-
-/// @brief Calculate the cross product of two 3-dimensional Vectors.
-///
-/// @param v1 Vector to multiply
-/// @param v2 Vector to multiply
-/// @return 3-dimensional vector that contains the result.
-template<class T>
-inline Vector<T, 3> cross(const Vector<T, 3>& v1, const Vector<T, 3>& v2) {
-  return Vector<T, 3>::CrossProduct(v1,v2);
-}
-
-/// @brief Calculate the dot product of two N-dimensional Vectors of any type.
-///
-/// @param v1 Vector to multiply
-/// @param v2 Vector to multiply
-/// @return Scalar dot product result.
-template<class TV>
-inline typename TV::Scalar dot(const TV& v1, const TV& v2) {
-  return TV::DotProduct(v1,v2);
-}
-
-/// @brief Normalize an N-dimensional Vector of an arbitrary type.
-///
-/// @param v1 Vector to normalize.
-/// @return Normalized vector.
-template<class TV>
-inline TV normalize(const TV& v1) {
-  return v1.Normalized();
-}
 
 /// @}
 

--- a/include/mathfu/hlsl_mappings.h
+++ b/include/mathfu/hlsl_mappings.h
@@ -98,35 +98,6 @@ typedef Matrix<uint, 3, 3> uint3x3;
 /// 4x4 <code>uint</code> Matrix.
 typedef Matrix<uint, 4, 4> uint4x4;
 
-/// @brief Calculate the cross product of two 3-dimensional Vectors.
-///
-/// @param v1 Vector to multiply
-/// @param v2 Vector to multiply
-/// @return 3-dimensional vector that contains the result.
-template <class T>
-inline Vector<T, 3> cross(const Vector<T, 3>& v1, const Vector<T, 3>& v2) {
-  return Vector<T, 3>::CrossProduct(v1, v2);
-}
-
-/// @brief Calculate the dot product of two N-dimensional Vectors of any type.
-///
-/// @param v1 Vector to multiply
-/// @param v2 Vector to multiply
-/// @return Scalar dot product result.
-template <class TV>
-inline typename TV::Scalar dot(const TV& v1, const TV& v2) {
-  return TV::DotProduct(v1, v2);
-}
-
-/// @brief Normalize an N-dimensional Vector of an arbitrary type.
-///
-/// @param v1 Vector to normalize.
-/// @return Normalized vector.
-template <class TV>
-inline TV normalize(const TV& v1) {
-  return v1.Normalized();
-}
-
 /// @}
 
 }  // namespace mathfu

--- a/include/mathfu/vector.h
+++ b/include/mathfu/vector.h
@@ -1065,6 +1065,40 @@ static inline CompatibleT ToTypeHelper(const Vector<T, Dims>& v) {
 
 /// @}
 
+/// @addtogroup mathfu_vector
+/// @{
+
+/// @brief Calculate the dot product of two N-dimensional Vectors.
+///
+/// @param v1 Vector to multiply.
+/// @param v2 Vector to multiply.
+/// @return Scalar dot product result.
+template <class T, int d>
+inline T dot(const Vector<T, d>& v1, const Vector<T, d>& v2) {
+  return Vector<T, d>::DotProduct(v1, v2);
+}
+
+/// @brief Calculate the cross product of two 3-dimensional Vectors.
+///
+/// @param v1 Vector to multiply.
+/// @param v2 Vector to multiply.
+/// @return 3-dimensional vector that contains the result.
+template <class T>
+inline Vector<T, 3> cross(const Vector<T, 3>& v1, const Vector<T, 3>& v2) {
+  return Vector<T, 3>::CrossProduct(v1, v2);
+}
+
+/// @brief Normalize an N-dimensional Vector.
+///
+/// @param v Vector to normalize.
+/// @return Normalized vector.
+template <class T, int d>
+inline Vector<T, d> normalize(const Vector<T, d>& v) {
+  return v.Normalized();
+}
+
+/// @}
+
 /// @addtogroup mathfu_utilities
 /// @{
 


### PR DESCRIPTION
## Summary

- Move `cross()`, `dot()`, and `normalize()` free functions from `glsl_mappings.h` and `hlsl_mappings.h` into `vector.h` where the `Vector` type is defined
- Replace the unconstrained `TV` template parameter on `dot()` and `normalize()` with properly constrained `Vector<T, d>` parameters
- Remove the now-redundant duplicate definitions from both mapping headers

## Changes

- **`include/mathfu/vector.h`**: Added `dot()`, `cross()`, and `normalize()` as free functions with `Vector<T, d>` template constraints, placed after the existing vector utility functions
- **`include/mathfu/glsl_mappings.h`**: Removed the duplicated `cross()`, `dot()`, and `normalize()` definitions (the functions are still available via the existing `#include "mathfu/vector.h"`)
- **`include/mathfu/hlsl_mappings.h`**: Same removal as above

## Testing

- Both `glsl_mappings.h` and `hlsl_mappings.h` already `#include "mathfu/vector.h"`, so all existing callers that include either mapping header will continue to find these functions through normal include resolution
- The constrained `Vector<T, d>` signatures are source-compatible with all previous valid call sites (any call that passed `Vector` arguments will still match)
- The only behavioral change is that `dot()` and `normalize()` will no longer match non-Vector types, which was the unconstrained `TV` template bug reported in the issue

Closes #67