### PR TITLE
Replace runtime handedness float with Handedness enum

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -103,6 +103,15 @@ enum class DepthRange {
   kDirectX  ///< z maps to [0, 1] (DirectX / Metal / Vulkan default)
 };
 
+/// @brief Specifies the coordinate system handedness.
+///
+/// Right-handed: +Z points out of the screen (OpenGL convention).
+/// Left-handed: +Z points into the screen (DirectX convention).
+enum class Handedness {
+  kRightHanded,  ///< Right-handed coordinate system (OpenGL default)
+  kLeftHanded    ///< Left-handed coordinate system (DirectX default)
+};
+
 /// @cond MATHFU_INTERNAL
 template <class T, int Rows, int Cols = Rows>
 class Matrix;
@@ -120,16 +129,18 @@ static inline Matrix<T, Rows, Cols> OuterProductHelper(
     const Vector<T, Rows>& v1, const Vector<T, Cols>& v2);
 template <class T>
 inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
-                                         T handedness, DepthRange depth_range);
+                                         Handedness handedness,
+                                         DepthRange depth_range);
 template <class T>
 static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
-                                          T znear, T zfar, T handedness,
+                                          T znear, T zfar,
+                                          Handedness handedness,
                                           DepthRange depth_range);
 template <class T>
 static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
                                            const Vector<T, 3>& eye,
                                            const Vector<T, 3>& up,
-                                           T handedness);
+                                           Handedness handedness);
 template <class T>
 static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
                                    const Matrix<T, 4, 4>& model_view,
@@ -817,12 +828,14 @@ class Matrix {
   /// @param aspect Aspect ratio.
   /// @param znear Near plane location.
   /// @param zfar Far plane location.
-  /// @param handedness 1.0f for RH, -1.0f for LH
+  /// @param handedness Handedness::kRightHanded (default) or
+  ///                   Handedness::kLeftHanded.
   /// @param depth_range DepthRange::kOpenGL for z in [-1,1] (default),
   ///                    DepthRange::kDirectX for z in [0,1].
   /// @return 4x4 perspective Matrix.
   static inline Matrix<T, 4, 4> Perspective(
-      T fovy, T aspect, T znear, T zfar, T handedness = 1,
+      T fovy, T aspect, T znear, T zfar,
+      Handedness handedness = Handedness::kRightHanded,
       DepthRange depth_range = DepthRange::kOpenGL) {
     return PerspectiveHelper(fovy, aspect, znear, zfar, handedness,
                              depth_range);
@@ -836,12 +849,14 @@ class Matrix {
   /// @param top Top extent.
   /// @param znear Near plane location.
   /// @param zfar Far plane location.
-  /// @param handedness 1.0f for RH, -1.0f for LH
+  /// @param handedness Handedness::kRightHanded (default) or
+  ///                   Handedness::kLeftHanded.
   /// @param depth_range DepthRange::kOpenGL for z in [-1,1] (default),
   ///                    DepthRange::kDirectX for z in [0,1].
   /// @return 4x4 orthographic Matrix.
   static inline Matrix<T, 4, 4> Ortho(
-      T left, T right, T bottom, T top, T znear, T zfar, T handedness = 1,
+      T left, T right, T bottom, T top, T znear, T zfar,
+      Handedness handedness = Handedness::kRightHanded,
       DepthRange depth_range = DepthRange::kOpenGL) {
     return OrthoHelper(left, right, bottom, top, znear, zfar, handedness,
                        depth_range);
@@ -853,12 +868,12 @@ class Matrix {
   /// @param eye The position of the camera.
   /// @param up The up vector in the world, for example (0, 1, 0) if the
   /// y-axis is up.
-  /// @param handedness 1.0f for RH, -1.0f for LH.
+  /// @param handedness Handedness::kRightHanded (default) or
+  ///                   Handedness::kLeftHanded.
   /// @return 3-dimensional camera Matrix.
-  static inline Matrix<T, 4, 4> LookAt(const Vector<T, 3>& at,
-                                       const Vector<T, 3>& eye,
-                                       const Vector<T, 3>& up,
-                                       T handedness = 1) {
+  static inline Matrix<T, 4, 4> LookAt(
+      const Vector<T, 3>& at, const Vector<T, 3>& eye, const Vector<T, 3>& up,
+      Handedness handedness = Handedness::kRightHanded) {
     return LookAtHelper(at, eye, up, handedness);
   }
 
@@ -1436,7 +1451,9 @@ bool InverseHelper(const Matrix<T, 4, 4>& m, Matrix<T, 4, 4>* const inverse,
 ///   m[3][2] = (znear * zfar) / (znear - zfar)
 template <class T>
 inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
-                                         T handedness, DepthRange depth_range) {
+                                         Handedness handedness,
+                                         DepthRange depth_range) {
+  const T h = (handedness == Handedness::kRightHanded) ? T(1) : T(-1);
   const T y = T(1) / std::tan(fovy * T(0.5));
   const T x = y / aspect;
   const T zdist = (znear - zfar);
@@ -1450,8 +1467,8 @@ inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
     zz = zfar / zdist;
     zw = znear * zfar / zdist;
   }
-  return Matrix<T, 4, 4>(x, 0, 0, 0, 0, y, 0, 0, 0, 0, zz * handedness,
-                         T(-1) * handedness, 0, 0, zw, 0);
+  return Matrix<T, 4, 4>(x, 0, 0, 0, 0, y, 0, 0, 0, 0, zz * h, T(-1) * h, 0, 0,
+                         zw, 0);
 }
 /// @endcond
 
@@ -1467,17 +1484,19 @@ inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
 ///   m[3][2] = -znear / (zfar - znear)
 template <class T>
 static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
-                                          T znear, T zfar, T handedness,
+                                          T znear, T zfar,
+                                          Handedness handedness,
                                           DepthRange depth_range) {
+  const T h = (handedness == Handedness::kRightHanded) ? T(1) : T(-1);
   const T zdist = zfar - znear;
   T zz, zw;
   if (depth_range == DepthRange::kOpenGL) {
     // OpenGL: near plane -> z = -1, far plane -> z = 1
-    zz = -handedness * static_cast<T>(2) / zdist;
+    zz = -h * static_cast<T>(2) / zdist;
     zw = -(zfar + znear) / zdist;
   } else {
     // DirectX: near plane -> z = 0, far plane -> z = 1
-    zz = -handedness * static_cast<T>(1) / zdist;
+    zz = -h * static_cast<T>(1) / zdist;
     zw = -znear / zdist;
   }
   return Matrix<T, 4, 4>(static_cast<T>(2) / (right - left), 0, 0, 0, 0,
@@ -1495,19 +1514,21 @@ static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
 template <class T>
 static void LookAtHelperCalculateAxes(const Vector<T, 3>& at,
                                       const Vector<T, 3>& eye,
-                                      const Vector<T, 3>& up, T handedness,
+                                      const Vector<T, 3>& up,
+                                      Handedness handedness,
                                       Vector<T, 3>* const axes) {
+  const T h = (handedness == Handedness::kRightHanded) ? T(1) : T(-1);
   // Notice that y-axis is always the same regardless of handedness.
   axes[2] = (at - eye).Normalized();
   axes[0] = Vector<T, 3>::CrossProduct(up, axes[2]).Normalized();
   axes[1] = Vector<T, 3>::CrossProduct(axes[2], axes[0]);
-  axes[3] = Vector<T, 3>(handedness * Vector<T, 3>::DotProduct(axes[0], eye),
+  axes[3] = Vector<T, 3>(h * Vector<T, 3>::DotProduct(axes[0], eye),
                          -Vector<T, 3>::DotProduct(axes[1], eye),
-                         handedness * Vector<T, 3>::DotProduct(axes[2], eye));
+                         h * Vector<T, 3>::DotProduct(axes[2], eye));
 
-  // Default calculation is left-handed (i.e. handedness=-1).
-  // Negate x and z axes for right-handed (i.e. handedness=+1) case.
-  const T neg = -handedness;
+  // Default calculation is left-handed (i.e. h=-1).
+  // Negate x and z axes for right-handed (i.e. h=+1) case.
+  const T neg = -h;
   axes[0] *= neg;
   axes[2] *= neg;
 }
@@ -1519,7 +1540,7 @@ template <class T>
 static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
                                            const Vector<T, 3>& eye,
                                            const Vector<T, 3>& up,
-                                           T handedness) {
+                                           Handedness handedness) {
   Vector<T, 3> axes[4];
   LookAtHelperCalculateAxes(at, eye, up, handedness, axes);
   const Vector<T, 4> column0(axes[0][0], axes[1][0], axes[2][0], 0);

--- a/include/mathfu/quaternion.h
+++ b/include/mathfu/quaternion.h
@@ -618,7 +618,8 @@ class Quaternion {
   ///
   /// @param forward The forward vector (Vector to face).
   /// @param up The up vector.
-  /// @param handedness 1.0f for RH, -1.0f for LH.
+  /// @param handedness Handedness::kRightHanded (default) or
+  ///                   Handedness::kLeftHanded.
   /// @param Forward and up do not have to be orthogonal.
   /// @param Forward and up cannot be parallel.
   /// @param Forward and up cannot be zero vectors.
@@ -629,8 +630,9 @@ class Quaternion {
   /// Matrix::LookAt takes destination and source as first and second param.
   /// The params can be represented with zero-vector as source and
   /// forward-vector as destination.
-  static inline Quaternion<T> LookAt(const Vector<T, 3>& forward,
-                                     const Vector<T, 3>& up, T handedness = 1) {
+  static inline Quaternion<T> LookAt(
+      const Vector<T, 3>& forward, const Vector<T, 3>& up,
+      Handedness handedness = Handedness::kRightHanded) {
     return FromMatrix(Matrix<T, 3>::LookAt(
         forward, Vector<T, 3>(static_cast<T>(0)), up, handedness));
   }

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -562,18 +562,20 @@ void Perspective_Test(const T& precision) {
   // clang-format off
   static const MatrixExpectation<T, 4, 4> kTestCases[] = {
     {
-      "normalized handedness=1",
+      "normalized handedness=RH",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 1, 0, 1, 1),
+          atan(static_cast<T>(1)) * 2, 1, 0, 1,
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4>(1, 0, 0, 0,
                            0, 1, 0, 0,
                            0, 0, -1, -1,
                            0, 0, 0, 0),
     },
     {
-      "normalized handedness=-1",
+      "normalized handedness=LH",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 1, 0, 1, -1),
+          atan(static_cast<T>(1)) * 2, 1, 0, 1,
+          mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4>(1, 0, 0, 0,
                            0, 1, 0, 0,
                            0, 0, 1, 1,
@@ -582,7 +584,8 @@ void Perspective_Test(const T& precision) {
     {
       "widefov",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(2)) * 2, 1, 0, 1, 1),
+          atan(static_cast<T>(2)) * 2, 1, 0, 1,
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4>(0.5, 0, 0, 0,
                            0, 0.5, 0, 0,
                            0, 0, -1, -1,
@@ -591,7 +594,8 @@ void Perspective_Test(const T& precision) {
     {
       "narrowfov",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(0.1)) * 2, 1, 0, 1, 1),
+          atan(static_cast<T>(0.1)) * 2, 1, 0, 1,
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4>(10, 0, 0, 0,
                            0, 10, 0, 0,
                            0, 0, -1, -1,
@@ -600,7 +604,8 @@ void Perspective_Test(const T& precision) {
     {
       "2:1 aspect ratio",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 0.5, 0, 1, 1),
+          atan(static_cast<T>(1)) * 2, 0.5, 0, 1,
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4>(2, 0, 0, 0,
                            0, 1, 0, 0,
                            0, 0, -1, -1,
@@ -609,7 +614,8 @@ void Perspective_Test(const T& precision) {
     {
       "deeper view frustrum",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 1, -2, 2, 1),
+          atan(static_cast<T>(1)) * 2, 1, -2, 2,
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4>(1, 0, 0, 0,
                            0, 1, 0, 0,
                            0, 0, 0, -1,
@@ -630,10 +636,10 @@ void PerspectiveOpenGLDepth_Test(const T& precision) {
   const T aspect = static_cast<T>(1.5);
   const T znear = static_cast<T>(0.1);
   const T zfar = static_cast<T>(100.0);
-  const T handedness = static_cast<T>(1);
 
   mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Perspective(
-      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kOpenGL);
+      fovy, aspect, znear, zfar, mathfu::Handedness::kRightHanded,
+      mathfu::DepthRange::kOpenGL);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -657,10 +663,10 @@ void PerspectiveDirectXDepth_Test(const T& precision) {
   const T aspect = static_cast<T>(1.5);
   const T znear = static_cast<T>(0.1);
   const T zfar = static_cast<T>(100.0);
-  const T handedness = static_cast<T>(1);
 
   mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Perspective(
-      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kDirectX);
+      fovy, aspect, znear, zfar, mathfu::Handedness::kRightHanded,
+      mathfu::DepthRange::kDirectX);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -684,12 +690,12 @@ void PerspectiveDefaultIsOpenGL_Test(const T& precision) {
   const T aspect = static_cast<T>(1.6);
   const T znear = static_cast<T>(1.0);
   const T zfar = static_cast<T>(500.0);
-  const T handedness = static_cast<T>(1);
 
-  mathfu::Matrix<T, 4> default_proj =
-      mathfu::Matrix<T, 4>::Perspective(fovy, aspect, znear, zfar, handedness);
+  mathfu::Matrix<T, 4> default_proj = mathfu::Matrix<T, 4>::Perspective(
+      fovy, aspect, znear, zfar, mathfu::Handedness::kRightHanded);
   mathfu::Matrix<T, 4> opengl_proj = mathfu::Matrix<T, 4>::Perspective(
-      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kOpenGL);
+      fovy, aspect, znear, zfar, mathfu::Handedness::kRightHanded,
+      mathfu::DepthRange::kOpenGL);
 
   for (int i = 0; i < 16; ++i) {
     EXPECT_NEAR(default_proj[i], opengl_proj[i], precision);
@@ -712,7 +718,8 @@ void Ortho_Test(const T& precision) {
     },
     {
       "normalized RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0,
+                                     mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -720,7 +727,8 @@ void Ortho_Test(const T& precision) {
     },
     {
       "narrow RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(1, 3, 0, 2, 2, 0, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(1, 3, 0, 2, 2, 0,
+                                     mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -729,7 +737,8 @@ void Ortho_Test(const T& precision) {
     },
     {
       "squat RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 1, 3, 2, 0, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 1, 3, 2, 0,
+                                     mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -738,7 +747,8 @@ void Ortho_Test(const T& precision) {
     },
     {
       "deep RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 3, 1, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 3, 1,
+                                     mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -747,7 +757,8 @@ void Ortho_Test(const T& precision) {
     },
     {
       "normalized LH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0, -1),
+      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0,
+                                     mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, -1, 0,
@@ -755,7 +766,8 @@ void Ortho_Test(const T& precision) {
     },
     {
       "Canonical LH",
-      mathfu::Matrix<T, 4, 4>::Ortho(1, 3, 1, 3, 1, 3, -1),
+      mathfu::Matrix<T, 4, 4>::Ortho(1, 3, 1, 3, 1, 3,
+                                     mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -779,11 +791,10 @@ void OrthoOpenGLDepth_Test(const T& precision) {
   const T top = static_cast<T>(10);
   const T znear = static_cast<T>(1);
   const T zfar = static_cast<T>(100);
-  const T handedness = static_cast<T>(1);
 
-  mathfu::Matrix<T, 4> proj =
-      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
-                                  handedness, mathfu::DepthRange::kOpenGL);
+  mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Ortho(
+      left, right, bottom, top, znear, zfar, mathfu::Handedness::kRightHanded,
+      mathfu::DepthRange::kOpenGL);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -809,11 +820,10 @@ void OrthoDirectXDepth_Test(const T& precision) {
   const T top = static_cast<T>(10);
   const T znear = static_cast<T>(1);
   const T zfar = static_cast<T>(100);
-  const T handedness = static_cast<T>(1);
 
-  mathfu::Matrix<T, 4> proj =
-      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
-                                  handedness, mathfu::DepthRange::kDirectX);
+  mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Ortho(
+      left, right, bottom, top, znear, zfar, mathfu::Handedness::kRightHanded,
+      mathfu::DepthRange::kDirectX);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -839,13 +849,12 @@ void OrthoDefaultIsOpenGL_Test(const T& precision) {
   const T top = static_cast<T>(5);
   const T znear = static_cast<T>(0.5);
   const T zfar = static_cast<T>(200);
-  const T handedness = static_cast<T>(1);
 
   mathfu::Matrix<T, 4> default_proj = mathfu::Matrix<T, 4>::Ortho(
-      left, right, bottom, top, znear, zfar, handedness);
-  mathfu::Matrix<T, 4> opengl_proj =
-      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
-                                  handedness, mathfu::DepthRange::kOpenGL);
+      left, right, bottom, top, znear, zfar, mathfu::Handedness::kRightHanded);
+  mathfu::Matrix<T, 4> opengl_proj = mathfu::Matrix<T, 4>::Ortho(
+      left, right, bottom, top, znear, zfar, mathfu::Handedness::kRightHanded,
+      mathfu::DepthRange::kOpenGL);
 
   for (int i = 0; i < 16; ++i) {
     EXPECT_NEAR(default_proj[i], opengl_proj[i], precision);
@@ -872,7 +881,8 @@ void LookAt_Test(const T& precision) {
       "left-handed origin along z",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 0, 1), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -882,7 +892,8 @@ void LookAt_Test(const T& precision) {
       "origin along diagonal",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 0, 0), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(
           static_cast<T>(-0.707106781), static_cast<T>(-0.408248290),
               static_cast<T>(-0.577350269), 0,
@@ -895,7 +906,8 @@ void LookAt_Test(const T& precision) {
       "origin along z",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 0, 2), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -905,7 +917,8 @@ void LookAt_Test(const T& precision) {
       "origin along x",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(1, 0, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(0, 0, 1, 0,
                               0, 1, 0, 0,
                               -1, 0, 0, 0,
@@ -915,7 +928,8 @@ void LookAt_Test(const T& precision) {
       "origin along y",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 1, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(1, 0, 0), -1),
+          mathfu::Vector<T, 3>(1, 0, 0),
+          mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(0, 1, 0, 0,
                               0, 0, 1, 0,
                               1, 0, 0, 0,
@@ -925,7 +939,8 @@ void LookAt_Test(const T& precision) {
       "translated eye, looking along z",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(1, 1, 2), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kLeftHanded),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -935,7 +950,8 @@ void LookAt_Test(const T& precision) {
       "right-handed diagonal along diagonal",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 0, 0), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(
           static_cast<T>(0.707106781), static_cast<T>(-0.408248290),
               static_cast<T>(0.577350269), 0,
@@ -948,7 +964,8 @@ void LookAt_Test(const T& precision) {
       "right-handed origin along z",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 0, 1), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(-1, 0, 0, 0,
                                0, 1, 0, 0,
                                0, 0, -1,0,
@@ -958,7 +975,8 @@ void LookAt_Test(const T& precision) {
       "right-handed origin along x",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(1, 0, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(0, 0, -1, 0,
                               0, 1, 0, 0,
                               1, 0, 0, 0,
@@ -968,7 +986,8 @@ void LookAt_Test(const T& precision) {
       "right-handed origin along y",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(0, 1, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(1, 0, 0), 1),
+          mathfu::Vector<T, 3>(1, 0, 0),
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(0, 1, 0, 0,
                               0, 0, -1, 0,
                               -1, 0, 0, 0,
@@ -978,7 +997,8 @@ void LookAt_Test(const T& precision) {
       "right-handed translated eye along x",
       mathfu::Matrix<T, 4, 4>::LookAt(
           mathfu::Vector<T, 3>(2, 1, 1), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0),
+          mathfu::Handedness::kRightHanded),
       mathfu::Matrix<T, 4, 4>(0, 0, -1, 0,
                               0, 1, 0, 0,
                               1, 0, 0, 0,

--- a/unit_tests/quaternion_test/quaternion_test.cpp
+++ b/unit_tests/quaternion_test/quaternion_test.cpp
@@ -672,14 +672,15 @@ void LookAt_Test(const T& precision) {
       mathfu::Quaternion<T>::LookAt(mathfu::Vector<T, 3>(zero, zero, one),
                                     mathfu::Vector<T, 3>(zero, one, zero)),
       mathfu::Quaternion<T>::LookAt(mathfu::Vector<T, 3>(zero, zero, one),
-                                    mathfu::Vector<T, 3>(zero, one, zero), one),
+                                    mathfu::Vector<T, 3>(zero, one, zero),
+                                    mathfu::Handedness::kRightHanded),
       precision);
   // Explicit left-handed: looking along +z with up +y produces identity.
   EXPECT_NEAR_QUAT(
       mathfu::Quaternion<T>::identity,
       mathfu::Quaternion<T>::LookAt(mathfu::Vector<T, 3>(zero, zero, one),
                                     mathfu::Vector<T, 3>(zero, one, zero),
-                                    static_cast<T>(-1)),
+                                    mathfu::Handedness::kLeftHanded),
       precision);
 }
 TEST_ALL_F(LookAt)


### PR DESCRIPTION
## Summary
- Add `Handedness` enum class (`kRightHanded`, `kLeftHanded`) to replace the runtime `T handedness` parameter (1.0 / -1.0) used by `LookAt`, `Perspective`, and `Ortho`.
- Update all function signatures, helper implementations, and call sites (including tests) to use the new enum.
- Default remains right-handed (`Handedness::kRightHanded`).

## Changes
- `include/mathfu/matrix.h`: Added `Handedness` enum next to `DepthRange`. Updated forward declarations, public API (`Perspective`, `Ortho`, `LookAt`), and internal helpers (`PerspectiveHelper`, `OrthoHelper`, `LookAtHelper`, `LookAtHelperCalculateAxes`) to accept `Handedness` instead of `T`. Each helper converts the enum to a `T` multiplier internally.
- `include/mathfu/quaternion.h`: Updated `Quaternion::LookAt` to accept `Handedness` instead of `T`.
- `unit_tests/matrix_test/matrix_test.cpp`: Updated all test call sites to use `mathfu::Handedness::kRightHanded` / `mathfu::Handedness::kLeftHanded`.
- `unit_tests/quaternion_test/quaternion_test.cpp`: Updated `LookAt_Test` call sites to use the new enum.

## Testing
- All 990 matrix and quaternion tests pass (across all SIMD/padding configurations).
- Verified that clang-format was applied to all changed files.

Closes #15