### PR TITLE
Make Matrix data_ member private

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -918,8 +918,19 @@ class Matrix {
   /// Total number of elements in the matrix.
   static const int kElements = Rows * Cols;
 
+  /// @brief Access the underlying column data array.
+  ///
+  /// @return Pointer to the first column vector.
+  inline const Vector<T, Rows>* data() const { return data_; }
+
+  /// @brief Access the underlying column data array.
+  ///
+  /// @return Pointer to the first column vector.
+  inline Vector<T, Rows>* data() { return data_; }
+
   MATHFU_DEFINE_CLASS_SIMD_AWARE_NEW_DELETE
 
+ private:
   Vector<T, Rows> data_[Cols];
 };
 /// @}
@@ -1017,9 +1028,9 @@ inline Vector<T, 2> operator*(const Matrix<T, 2, 2>& m, const Vector<T, 2>& v) {
 /// @cond MATHFU_INTERNAL
 template <class T>
 inline Vector<T, 3> operator*(const Matrix<T, 3, 3>& m, const Vector<T, 3>& v) {
-  return Vector<T, 3>(MATHFU_MATRIX_3X3_DOT(&m.data_[0].data_[0], v, 0, 3),
-                      MATHFU_MATRIX_3X3_DOT(&m.data_[0].data_[0], v, 1, 3),
-                      MATHFU_MATRIX_3X3_DOT(&m.data_[0].data_[0], v, 2, 3));
+  return Vector<T, 3>(MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 0, 3),
+                      MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 1, 3),
+                      MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 2, 3));
 }
 /// @endcond
 
@@ -1028,11 +1039,11 @@ template <>
 inline Vector<float, 3> operator*(const Matrix<float, 3, 3>& m,
                                   const Vector<float, 3>& v) {
   return Vector<float, 3>(
-      MATHFU_MATRIX_3X3_DOT(&m.data_[0].data_[0], v, 0,
+      MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 0,
                             MATHFU_VECTOR_STRIDE_FLOATS(v)),
-      MATHFU_MATRIX_3X3_DOT(&m.data_[0].data_[0], v, 1,
+      MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 1,
                             MATHFU_VECTOR_STRIDE_FLOATS(v)),
-      MATHFU_MATRIX_3X3_DOT(&m.data_[0].data_[0], v, 2,
+      MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 2,
                             MATHFU_VECTOR_STRIDE_FLOATS(v)));
 }
 /// @endcond
@@ -1040,10 +1051,10 @@ inline Vector<float, 3> operator*(const Matrix<float, 3, 3>& m,
 /// @cond MATHFU_INTERNAL
 template <class T>
 inline Vector<T, 4> operator*(const Matrix<T, 4, 4>& m, const Vector<T, 4>& v) {
-  return Vector<T, 4>(MATHFU_MATRIX_4X4_DOT(&m.data_[0].data_[0], v, 0),
-                      MATHFU_MATRIX_4X4_DOT(&m.data_[0].data_[0], v, 1),
-                      MATHFU_MATRIX_4X4_DOT(&m.data_[0].data_[0], v, 2),
-                      MATHFU_MATRIX_4X4_DOT(&m.data_[0].data_[0], v, 3));
+  return Vector<T, 4>(MATHFU_MATRIX_4X4_DOT(&m.GetColumn(0).data_[0], v, 0),
+                      MATHFU_MATRIX_4X4_DOT(&m.GetColumn(0).data_[0], v, 1),
+                      MATHFU_MATRIX_4X4_DOT(&m.GetColumn(0).data_[0], v, 2),
+                      MATHFU_MATRIX_4X4_DOT(&m.GetColumn(0).data_[0], v, 3));
 }
 /// @endcond
 


### PR DESCRIPTION
## Summary
Make the `data_` member of `Matrix` private to match the private naming convention (trailing underscore), and add public `data()` accessor methods. Closes #71.

## Changes
- Moved `Vector<T, Rows> data_[Cols]` from the public section to a new private section of the `Matrix` class
- Added `const Vector<T, Rows>* data() const` and `Vector<T, Rows>* data()` public accessor methods
- Updated the three free `operator*` specializations (3x3 template, 3x3 float, 4x4 template) for matrix-vector multiplication to use `GetColumn(0)` instead of directly accessing `data_[0]`, since these are non-member functions
- Internal member functions and macros (`MATHFU_MAT_OPERATOR`, `MATHFU_MAT_SELF_OPERATOR`) continue to access `data_` directly as they are within the class scope
- The existing friend `operator*` (Vector * Matrix) declared inside the class body retains access

## Testing
- All 886 matrix tests pass
- All 104 quaternion tests pass
- All benchmark targets compile successfully