### PR TITLE
Replace runtime handedness parameter with compile-time template parameter

### DIFF
--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -104,6 +104,16 @@ enum class DepthRange {
   kDirectX  ///< z maps to [0, 1] (DirectX / Metal / Vulkan default)
 };
 
+/// @brief Specifies the coordinate system handedness for projection and view
+/// matrices.
+///
+/// Right-handed is the default and matches OpenGL conventions.
+/// Left-handed matches DirectX conventions.
+enum class Handedness {
+  kRightHanded = 1,  ///< Right-handed coordinate system (OpenGL convention)
+  kLeftHanded = -1   ///< Left-handed coordinate system (DirectX convention)
+};
+
 /// @cond MATHFU_INTERNAL
 template <class T, int Rows, int Cols = Rows>
 class Matrix;
@@ -119,18 +129,17 @@ inline void TimesHelper(const Matrix<T, size1, size2>& m1,
 template <class T, int Rows, int Cols>
 static inline Matrix<T, Rows, Cols> OuterProductHelper(
     const Vector<T, Rows>& v1, const Vector<T, Cols>& v2);
-template <class T>
+template <class T, Handedness H>
 inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
-                                         T handedness, DepthRange depth_range);
-template <class T>
+                                         DepthRange depth_range);
+template <class T, Handedness H>
 static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
-                                          T znear, T zfar, T handedness,
+                                          T znear, T zfar,
                                           DepthRange depth_range);
-template <class T>
+template <class T, Handedness H>
 static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
                                            const Vector<T, 3>& eye,
-                                           const Vector<T, 3>& up,
-                                           T handedness);
+                                           const Vector<T, 3>& up);
 template <class T>
 static inline bool UnProjectHelper(const Vector<T, 3>& window_coord,
                                    const Matrix<T, 4, 4>& model_view,
@@ -846,53 +855,57 @@ class Matrix {
 
   /// @brief Create a 4x4 perspective Matrix.
   ///
+  /// @tparam H Coordinate system handedness
+  ///           (Handedness::kRightHanded or Handedness::kLeftHanded).
   /// @param fovy Field of view.
   /// @param aspect Aspect ratio.
   /// @param znear Near plane location.
   /// @param zfar Far plane location.
-  /// @param handedness 1.0f for RH, -1.0f for LH
   /// @param depth_range DepthRange::kOpenGL for z in [-1,1] (default),
   ///                    DepthRange::kDirectX for z in [0,1].
   /// @return 4x4 perspective Matrix.
+  template <Handedness H = Handedness::kRightHanded>
   static inline Matrix<T, 4, 4> Perspective(
-      T fovy, T aspect, T znear, T zfar, T handedness = 1,
+      T fovy, T aspect, T znear, T zfar,
       DepthRange depth_range = DepthRange::kOpenGL) {
-    return PerspectiveHelper(fovy, aspect, znear, zfar, handedness,
-                             depth_range);
+    return PerspectiveHelper<T, H>(fovy, aspect, znear, zfar, depth_range);
   }
 
   /// @brief Create a 4x4 orthographic Matrix.
   ///
+  /// @tparam H Coordinate system handedness
+  ///           (Handedness::kRightHanded or Handedness::kLeftHanded).
   /// @param left Left extent.
   /// @param right Right extent.
   /// @param bottom Bottom extent.
   /// @param top Top extent.
   /// @param znear Near plane location.
   /// @param zfar Far plane location.
-  /// @param handedness 1.0f for RH, -1.0f for LH
   /// @param depth_range DepthRange::kOpenGL for z in [-1,1] (default),
   ///                    DepthRange::kDirectX for z in [0,1].
   /// @return 4x4 orthographic Matrix.
+  template <Handedness H = Handedness::kRightHanded>
   static inline Matrix<T, 4, 4> Ortho(
-      T left, T right, T bottom, T top, T znear, T zfar, T handedness = 1,
+      T left, T right, T bottom, T top, T znear, T zfar,
       DepthRange depth_range = DepthRange::kOpenGL) {
-    return OrthoHelper(left, right, bottom, top, znear, zfar, handedness,
-                       depth_range);
+    return OrthoHelper<T, H>(left, right, bottom, top, znear, zfar,
+                             depth_range);
   }
 
   /// @brief Create a 3-dimensional camera Matrix.
   ///
+  /// @tparam H Coordinate system handedness
+  ///           (Handedness::kRightHanded or Handedness::kLeftHanded).
   /// @param at The look-at target of the camera.
   /// @param eye The position of the camera.
   /// @param up The up vector in the world, for example (0, 1, 0) if the
   /// y-axis is up.
-  /// @param handedness 1.0f for RH, -1.0f for LH.
   /// @return 3-dimensional camera Matrix.
+  template <Handedness H = Handedness::kRightHanded>
   static inline Matrix<T, 4, 4> LookAt(const Vector<T, 3>& at,
                                        const Vector<T, 3>& eye,
-                                       const Vector<T, 3>& up,
-                                       T handedness = 1) {
-    return LookAtHelper(at, eye, up, handedness);
+                                       const Vector<T, 3>& up) {
+    return LookAtHelper<T, H>(at, eye, up);
   }
 
   /// @brief Create a 3-dimensional transform Matrix.
@@ -1552,9 +1565,10 @@ bool InverseHelper(const Matrix<T, 4, 4>& m, Matrix<T, 4, 4>* const inverse,
 /// DirectX convention (z maps to [0, 1]):
 ///   m[2][2] = zfar / (znear - zfar)
 ///   m[3][2] = (znear * zfar) / (znear - zfar)
-template <class T>
+template <class T, Handedness H>
 inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
-                                         T handedness, DepthRange depth_range) {
+                                         DepthRange depth_range) {
+  const T handedness = static_cast<T>(H);
   const T y = T(1) / std::tan(fovy * T(0.5));
   const T x = y / aspect;
   const T zdist = (znear - zfar);
@@ -1583,10 +1597,11 @@ inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
 /// DirectX convention (z maps to [0, 1]):
 ///   m[2][2] = -1 / (zfar - znear)
 ///   m[3][2] = -znear / (zfar - znear)
-template <class T>
+template <class T, Handedness H>
 static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
-                                          T znear, T zfar, T handedness,
+                                          T znear, T zfar,
                                           DepthRange depth_range) {
+  const T handedness = static_cast<T>(H);
   const T zdist = zfar - znear;
   T zz, zw;
   if (depth_range == DepthRange::kOpenGL) {
@@ -1610,11 +1625,12 @@ static inline Matrix<T, 4, 4> OrthoHelper(T left, T right, T bottom, T top,
 /// Calculate the axes required to construct a 3-dimensional camera matrix that
 /// looks at "at" from eye position "eye" with the up vector "up".  The axes
 /// are returned in a 4 element "axes" array.
-template <class T>
+template <class T, Handedness H>
 static void LookAtHelperCalculateAxes(const Vector<T, 3>& at,
                                       const Vector<T, 3>& eye,
-                                      const Vector<T, 3>& up, T handedness,
+                                      const Vector<T, 3>& up,
                                       Vector<T, 3>* const axes) {
+  const T handedness = static_cast<T>(H);
   // Notice that y-axis is always the same regardless of handedness.
   axes[2] = (at - eye).Normalized();
   axes[0] = Vector<T, 3>::CrossProduct(up, axes[2]).Normalized();
@@ -1633,13 +1649,12 @@ static void LookAtHelperCalculateAxes(const Vector<T, 3>& at,
 
 /// @cond MATHFU_INTERNAL
 /// Create a 3-dimensional camera matrix.
-template <class T>
+template <class T, Handedness H>
 static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
                                            const Vector<T, 3>& eye,
-                                           const Vector<T, 3>& up,
-                                           T handedness) {
+                                           const Vector<T, 3>& up) {
   Vector<T, 3> axes[4];
-  LookAtHelperCalculateAxes(at, eye, up, handedness, axes);
+  LookAtHelperCalculateAxes<T, H>(at, eye, up, axes);
   const Vector<T, 4> column0(axes[0][0], axes[1][0], axes[2][0], 0);
   const Vector<T, 4> column1(axes[0][1], axes[1][1], axes[2][1], 0);
   const Vector<T, 4> column2(axes[0][2], axes[1][2], axes[2][2], 0);

--- a/include/mathfu/quaternion.h
+++ b/include/mathfu/quaternion.h
@@ -650,9 +650,10 @@ class Quaternion {
 
   /// @brief Returns a quaternion looking at forward vector with an up vector.
   ///
+  /// @tparam H Coordinate system handedness
+  ///           (Handedness::kRightHanded or Handedness::kLeftHanded).
   /// @param forward The forward vector (Vector to face).
   /// @param up The up vector.
-  /// @param handedness 1.0f for RH, -1.0f for LH.
   /// @param Forward and up do not have to be orthogonal.
   /// @param Forward and up cannot be parallel.
   /// @param Forward and up cannot be zero vectors.
@@ -663,15 +664,15 @@ class Quaternion {
   /// Matrix::LookAt takes destination and source as first and second param.
   /// The params can be represented with zero-vector as source and
   /// forward-vector as destination.
+  template <Handedness H = Handedness::kRightHanded>
   static inline Quaternion<T> LookAt(const Vector<T, 3>& forward,
-                                     const Vector<T, 3>& up, T handedness = 1) {
+                                     const Vector<T, 3>& up) {
     // Matrix::LookAt produces a view matrix (world-to-camera transform).
     // Its rotation part is the inverse of the camera's world orientation.
     // Since the inverse of a unit quaternion is its conjugate, we conjugate
     // the result to obtain the camera's orientation quaternion.
-    return FromMatrix(Matrix<T, 4>::LookAt(forward,
-                                           Vector<T, 3>(static_cast<T>(0)), up,
-                                           handedness))
+    return FromMatrix(Matrix<T, 4>::template LookAt<H>(
+                          forward, Vector<T, 3>(static_cast<T>(0)), up))
         .Conjugate();
   }
 

--- a/unit_tests/frustum_test/frustum_test.cpp
+++ b/unit_tests/frustum_test/frustum_test.cpp
@@ -50,14 +50,13 @@ using Mat4 = mathfu::Matrix<T, 4, 4>;
 // Maps x in [-hw, hw], y in [-hh, hh], z in [-near, -far] to NDC.
 template <class T>
 Mat4<T> MakeOrthoMatrix(T hw, T hh, T near_val, T far_val) {
-  return Mat4<T>::Ortho(-hw, hw, -hh, hh, near_val, far_val, static_cast<T>(1));
+  return Mat4<T>::Ortho(-hw, hw, -hh, hh, near_val, far_val);
 }
 
 // Helper to create a symmetric perspective projection matrix for testing.
 template <class T>
 Mat4<T> MakePerspectiveMatrix(T fovy, T aspect, T near_val, T far_val) {
-  return Mat4<T>::Perspective(fovy, aspect, near_val, far_val,
-                              static_cast<T>(1));
+  return Mat4<T>::Perspective(fovy, aspect, near_val, far_val);
 }
 
 // Test: Construction from 6 planes.

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -19,6 +19,7 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 #include "gtest/gtest.h"
 #include "mathfu/io.h"
@@ -579,30 +580,25 @@ void VerifyMatrixExpectations(
 // Test perspective matrix calculation.
 template <class T>
 void Perspective_Test(const T& precision) {
+  using RH = std::integral_constant<mathfu::Handedness,
+                                    mathfu::Handedness::kRightHanded>;
+  using LH = std::integral_constant<mathfu::Handedness,
+                                    mathfu::Handedness::kLeftHanded>;
   // clang-format off
-  static const MatrixExpectation<T, 4, 4> kTestCases[] = {
+  const MatrixExpectation<T, 4, 4> kTestCasesRH[] = {
     {
-      "normalized handedness=1",
-      mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 1, 0, 1, 1),
+      "normalized right-handed",
+      mathfu::Matrix<T, 4>::template Perspective<RH::value>(
+          atan(static_cast<T>(1)) * 2, 1, 0, 1),
       mathfu::Matrix<T, 4>(1, 0, 0, 0,
                            0, 1, 0, 0,
                            0, 0, -1, -1,
                            0, 0, 0, 0),
     },
     {
-      "normalized handedness=-1",
-      mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 1, 0, 1, -1),
-      mathfu::Matrix<T, 4>(1, 0, 0, 0,
-                           0, 1, 0, 0,
-                           0, 0, 1, 1,
-                           0, 0, 0, 0),
-    },
-    {
       "widefov",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(2)) * 2, 1, 0, 1, 1),
+          atan(static_cast<T>(2)) * 2, 1, 0, 1),
       mathfu::Matrix<T, 4>(0.5, 0, 0, 0,
                            0, 0.5, 0, 0,
                            0, 0, -1, -1,
@@ -611,7 +607,7 @@ void Perspective_Test(const T& precision) {
     {
       "narrowfov",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(0.1)) * 2, 1, 0, 1, 1),
+          atan(static_cast<T>(0.1)) * 2, 1, 0, 1),
       mathfu::Matrix<T, 4>(10, 0, 0, 0,
                            0, 10, 0, 0,
                            0, 0, -1, -1,
@@ -620,7 +616,7 @@ void Perspective_Test(const T& precision) {
     {
       "2:1 aspect ratio",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 0.5, 0, 1, 1),
+          atan(static_cast<T>(1)) * 2, 0.5, 0, 1),
       mathfu::Matrix<T, 4>(2, 0, 0, 0,
                            0, 1, 0, 0,
                            0, 0, -1, -1,
@@ -629,16 +625,29 @@ void Perspective_Test(const T& precision) {
     {
       "deeper view frustrum",
       mathfu::Matrix<T, 4>::Perspective(
-          atan(static_cast<T>(1)) * 2, 1, -2, 2, 1),
+          atan(static_cast<T>(1)) * 2, 1, -2, 2),
       mathfu::Matrix<T, 4>(1, 0, 0, 0,
                            0, 1, 0, 0,
                            0, 0, 0, -1,
                            0, 0, 2, 0),
     },
   };
+  const MatrixExpectation<T, 4, 4> kTestCasesLH[] = {
+    {
+      "normalized left-handed",
+      mathfu::Matrix<T, 4>::template Perspective<LH::value>(
+          atan(static_cast<T>(1)) * 2, 1, 0, 1),
+      mathfu::Matrix<T, 4>(1, 0, 0, 0,
+                           0, 1, 0, 0,
+                           0, 0, 1, 1,
+                           0, 0, 0, 0),
+    },
+  };
   // clang-format on
   VerifyMatrixExpectations(
-      kTestCases, sizeof(kTestCases) / sizeof(kTestCases[0]), precision);
+      kTestCasesRH, sizeof(kTestCasesRH) / sizeof(kTestCasesRH[0]), precision);
+  VerifyMatrixExpectations(
+      kTestCasesLH, sizeof(kTestCasesLH) / sizeof(kTestCasesLH[0]), precision);
 }
 TEST_SCALAR_F(Perspective, FLOAT_PRECISION, DOUBLE_PRECISION * 10)
 
@@ -650,10 +659,9 @@ void PerspectiveOpenGLDepth_Test(const T& precision) {
   const T aspect = static_cast<T>(1.5);
   const T znear = static_cast<T>(0.1);
   const T zfar = static_cast<T>(100.0);
-  const T handedness = static_cast<T>(1);
 
   mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Perspective(
-      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kOpenGL);
+      fovy, aspect, znear, zfar, mathfu::DepthRange::kOpenGL);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -677,10 +685,9 @@ void PerspectiveDirectXDepth_Test(const T& precision) {
   const T aspect = static_cast<T>(1.5);
   const T znear = static_cast<T>(0.1);
   const T zfar = static_cast<T>(100.0);
-  const T handedness = static_cast<T>(1);
 
   mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Perspective(
-      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kDirectX);
+      fovy, aspect, znear, zfar, mathfu::DepthRange::kDirectX);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -704,12 +711,11 @@ void PerspectiveDefaultIsOpenGL_Test(const T& precision) {
   const T aspect = static_cast<T>(1.6);
   const T znear = static_cast<T>(1.0);
   const T zfar = static_cast<T>(500.0);
-  const T handedness = static_cast<T>(1);
 
   mathfu::Matrix<T, 4> default_proj =
-      mathfu::Matrix<T, 4>::Perspective(fovy, aspect, znear, zfar, handedness);
+      mathfu::Matrix<T, 4>::Perspective(fovy, aspect, znear, zfar);
   mathfu::Matrix<T, 4> opengl_proj = mathfu::Matrix<T, 4>::Perspective(
-      fovy, aspect, znear, zfar, handedness, mathfu::DepthRange::kOpenGL);
+      fovy, aspect, znear, zfar, mathfu::DepthRange::kOpenGL);
 
   for (int i = 0; i < 16; ++i) {
     EXPECT_NEAR(default_proj[i], opengl_proj[i], precision);
@@ -720,8 +726,10 @@ TEST_SCALAR_F(PerspectiveDefaultIsOpenGL, FLOAT_PRECISION, DOUBLE_PRECISION)
 // Test orthographic matrix calculation.
 template <class T>
 void Ortho_Test(const T& precision) {
+  using LH = std::integral_constant<mathfu::Handedness,
+                                    mathfu::Handedness::kLeftHanded>;
   // clang-format off
-  static const MatrixExpectation<T, 4, 4> kTestCases[] = {
+  const MatrixExpectation<T, 4, 4> kTestCasesRH[] = {
     {
       "normalized",
       mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0),
@@ -732,7 +740,7 @@ void Ortho_Test(const T& precision) {
     },
     {
       "normalized RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -740,7 +748,7 @@ void Ortho_Test(const T& precision) {
     },
     {
       "narrow RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(1, 3, 0, 2, 2, 0, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(1, 3, 0, 2, 2, 0),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -749,7 +757,7 @@ void Ortho_Test(const T& precision) {
     },
     {
       "squat RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 1, 3, 2, 0, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 1, 3, 2, 0),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -758,16 +766,18 @@ void Ortho_Test(const T& precision) {
     },
     {
       "deep RH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 3, 1, 1),
+      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 3, 1),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
                               -1, -1, 2, 1),
 
     },
+  };
+  const MatrixExpectation<T, 4, 4> kTestCasesLH[] = {
     {
       "normalized LH",
-      mathfu::Matrix<T, 4, 4>::Ortho(0, 2, 0, 2, 2, 0, -1),
+      mathfu::Matrix<T, 4, 4>::template Ortho<LH::value>(0, 2, 0, 2, 2, 0),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, -1, 0,
@@ -775,7 +785,7 @@ void Ortho_Test(const T& precision) {
     },
     {
       "Canonical LH",
-      mathfu::Matrix<T, 4, 4>::Ortho(1, 3, 1, 3, 1, 3, -1),
+      mathfu::Matrix<T, 4, 4>::template Ortho<LH::value>(1, 3, 1, 3, 1, 3),
       mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
                               0, 1, 0, 0,
                               0, 0, 1, 0,
@@ -785,7 +795,9 @@ void Ortho_Test(const T& precision) {
   };
   // clang-format on
   VerifyMatrixExpectations(
-      kTestCases, sizeof(kTestCases) / sizeof(kTestCases[0]), precision);
+      kTestCasesRH, sizeof(kTestCasesRH) / sizeof(kTestCasesRH[0]), precision);
+  VerifyMatrixExpectations(
+      kTestCasesLH, sizeof(kTestCasesLH) / sizeof(kTestCasesLH[0]), precision);
 }
 TEST_SCALAR_F(Ortho, FLOAT_PRECISION, DOUBLE_PRECISION)
 
@@ -799,11 +811,9 @@ void OrthoOpenGLDepth_Test(const T& precision) {
   const T top = static_cast<T>(10);
   const T znear = static_cast<T>(1);
   const T zfar = static_cast<T>(100);
-  const T handedness = static_cast<T>(1);
 
-  mathfu::Matrix<T, 4> proj =
-      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
-                                  handedness, mathfu::DepthRange::kOpenGL);
+  mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Ortho(
+      left, right, bottom, top, znear, zfar, mathfu::DepthRange::kOpenGL);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -829,11 +839,9 @@ void OrthoDirectXDepth_Test(const T& precision) {
   const T top = static_cast<T>(10);
   const T znear = static_cast<T>(1);
   const T zfar = static_cast<T>(100);
-  const T handedness = static_cast<T>(1);
 
-  mathfu::Matrix<T, 4> proj =
-      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
-                                  handedness, mathfu::DepthRange::kDirectX);
+  mathfu::Matrix<T, 4> proj = mathfu::Matrix<T, 4>::Ortho(
+      left, right, bottom, top, znear, zfar, mathfu::DepthRange::kDirectX);
 
   // Transform a point on the near plane (z = -znear in view space for RH).
   mathfu::Vector<T, 4> near_point(0, 0, -znear, 1);
@@ -859,13 +867,11 @@ void OrthoDefaultIsOpenGL_Test(const T& precision) {
   const T top = static_cast<T>(5);
   const T znear = static_cast<T>(0.5);
   const T zfar = static_cast<T>(200);
-  const T handedness = static_cast<T>(1);
 
-  mathfu::Matrix<T, 4> default_proj = mathfu::Matrix<T, 4>::Ortho(
-      left, right, bottom, top, znear, zfar, handedness);
-  mathfu::Matrix<T, 4> opengl_proj =
-      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar,
-                                  handedness, mathfu::DepthRange::kOpenGL);
+  mathfu::Matrix<T, 4> default_proj =
+      mathfu::Matrix<T, 4>::Ortho(left, right, bottom, top, znear, zfar);
+  mathfu::Matrix<T, 4> opengl_proj = mathfu::Matrix<T, 4>::Ortho(
+      left, right, bottom, top, znear, zfar, mathfu::DepthRange::kOpenGL);
 
   for (int i = 0; i < 16; ++i) {
     EXPECT_NEAR(default_proj[i], opengl_proj[i], precision);
@@ -876,8 +882,12 @@ TEST_SCALAR_F(OrthoDefaultIsOpenGL, FLOAT_PRECISION, DOUBLE_PRECISION)
 // Test look-at matrix calculation.
 template <class T>
 void LookAt_Test(const T& precision) {
+  using RH = std::integral_constant<mathfu::Handedness,
+                                    mathfu::Handedness::kRightHanded>;
+  using LH = std::integral_constant<mathfu::Handedness,
+                                    mathfu::Handedness::kLeftHanded>;
   // clang-format off
-  static const MatrixExpectation<T, 4, 4> kTestCases[] = {
+  const MatrixExpectation<T, 4, 4> kTestCasesRH[] = {
     {
       "default RH origin along z",
       mathfu::Matrix<T, 4, 4>::LookAt(
@@ -889,73 +899,10 @@ void LookAt_Test(const T& precision) {
                                0, 0, 0, 1),
     },
     {
-      "left-handed origin along z",
-      mathfu::Matrix<T, 4, 4>::LookAt(
-          mathfu::Vector<T, 3>(0, 0, 1), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
-      mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
-                              0, 1, 0, 0,
-                              0, 0, 1, 0,
-                              0, 0, 0, 1),
-    },
-    {
-      "origin along diagonal",
-      mathfu::Matrix<T, 4, 4>::LookAt(
-          mathfu::Vector<T, 3>(0, 0, 0), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
-      mathfu::Matrix<T, 4, 4>(
-          static_cast<T>(-0.707106781), static_cast<T>(-0.408248290),
-              static_cast<T>(-0.577350269), 0,
-          0, static_cast<T>(0.816496580), static_cast<T>(-0.577350269), 0,
-          static_cast<T>(0.707106781), static_cast<T>(-0.408248290),
-              static_cast<T>(-0.577350269), 0,
-          0, 0, static_cast<T>(1.732050808), 1),
-    },
-    {
-      "origin along z",
-      mathfu::Matrix<T, 4, 4>::LookAt(
-          mathfu::Vector<T, 3>(0, 0, 2), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
-      mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
-                              0, 1, 0, 0,
-                              0, 0, 1, 0,
-                              0, 0, 0, 1),
-    },
-    {
-      "origin along x",
-      mathfu::Matrix<T, 4, 4>::LookAt(
-          mathfu::Vector<T, 3>(1, 0, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
-      mathfu::Matrix<T, 4, 4>(0, 0, 1, 0,
-                              0, 1, 0, 0,
-                              -1, 0, 0, 0,
-                              0, 0, 0, 1),
-    },
-    {
-      "origin along y",
-      mathfu::Matrix<T, 4, 4>::LookAt(
-          mathfu::Vector<T, 3>(0, 1, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(1, 0, 0), -1),
-      mathfu::Matrix<T, 4, 4>(0, 1, 0, 0,
-                              0, 0, 1, 0,
-                              1, 0, 0, 0,
-                              0, 0, 0, 1),
-    },
-    {
-      "translated eye, looking along z",
-      mathfu::Matrix<T, 4, 4>::LookAt(
-          mathfu::Vector<T, 3>(1, 1, 2), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), -1),
-      mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
-                              0, 1, 0, 0,
-                              0, 0, 1, 0,
-                              -1, -1, -1, 1),
-    },
-    {
       "right-handed diagonal along diagonal",
-      mathfu::Matrix<T, 4, 4>::LookAt(
+      mathfu::Matrix<T, 4, 4>::template LookAt<RH::value>(
           mathfu::Vector<T, 3>(0, 0, 0), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0)),
       mathfu::Matrix<T, 4, 4>(
           static_cast<T>(0.707106781), static_cast<T>(-0.408248290),
               static_cast<T>(0.577350269), 0,
@@ -966,9 +913,9 @@ void LookAt_Test(const T& precision) {
     },
     {
       "right-handed origin along z",
-      mathfu::Matrix<T, 4, 4>::LookAt(
+      mathfu::Matrix<T, 4, 4>::template LookAt<RH::value>(
           mathfu::Vector<T, 3>(0, 0, 1), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0)),
       mathfu::Matrix<T, 4, 4>(-1, 0, 0, 0,
                                0, 1, 0, 0,
                                0, 0, -1,0,
@@ -976,9 +923,9 @@ void LookAt_Test(const T& precision) {
     },
     {
       "right-handed origin along x",
-      mathfu::Matrix<T, 4, 4>::LookAt(
+      mathfu::Matrix<T, 4, 4>::template LookAt<RH::value>(
           mathfu::Vector<T, 3>(1, 0, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0)),
       mathfu::Matrix<T, 4, 4>(0, 0, -1, 0,
                               0, 1, 0, 0,
                               1, 0, 0, 0,
@@ -986,9 +933,9 @@ void LookAt_Test(const T& precision) {
     },
     {
       "right-handed origin along y",
-      mathfu::Matrix<T, 4, 4>::LookAt(
+      mathfu::Matrix<T, 4, 4>::template LookAt<RH::value>(
           mathfu::Vector<T, 3>(0, 1, 0), mathfu::Vector<T, 3>(0, 0, 0),
-          mathfu::Vector<T, 3>(1, 0, 0), 1),
+          mathfu::Vector<T, 3>(1, 0, 0)),
       mathfu::Matrix<T, 4, 4>(0, 1, 0, 0,
                               0, 0, -1, 0,
                               -1, 0, 0, 0,
@@ -996,18 +943,85 @@ void LookAt_Test(const T& precision) {
     },
     {
       "right-handed translated eye along x",
-      mathfu::Matrix<T, 4, 4>::LookAt(
+      mathfu::Matrix<T, 4, 4>::template LookAt<RH::value>(
           mathfu::Vector<T, 3>(2, 1, 1), mathfu::Vector<T, 3>(1, 1, 1),
-          mathfu::Vector<T, 3>(0, 1, 0), 1),
+          mathfu::Vector<T, 3>(0, 1, 0)),
       mathfu::Matrix<T, 4, 4>(0, 0, -1, 0,
                               0, 1, 0, 0,
                               1, 0, 0, 0,
                              -1,-1, 1, 1),
     },
   };
+  const MatrixExpectation<T, 4, 4> kTestCasesLH[] = {
+    {
+      "left-handed origin along z",
+      mathfu::Matrix<T, 4, 4>::template LookAt<LH::value>(
+          mathfu::Vector<T, 3>(0, 0, 1), mathfu::Vector<T, 3>(0, 0, 0),
+          mathfu::Vector<T, 3>(0, 1, 0)),
+      mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
+                              0, 1, 0, 0,
+                              0, 0, 1, 0,
+                              0, 0, 0, 1),
+    },
+    {
+      "origin along diagonal",
+      mathfu::Matrix<T, 4, 4>::template LookAt<LH::value>(
+          mathfu::Vector<T, 3>(0, 0, 0), mathfu::Vector<T, 3>(1, 1, 1),
+          mathfu::Vector<T, 3>(0, 1, 0)),
+      mathfu::Matrix<T, 4, 4>(
+          static_cast<T>(-0.707106781), static_cast<T>(-0.408248290),
+              static_cast<T>(-0.577350269), 0,
+          0, static_cast<T>(0.816496580), static_cast<T>(-0.577350269), 0,
+          static_cast<T>(0.707106781), static_cast<T>(-0.408248290),
+              static_cast<T>(-0.577350269), 0,
+          0, 0, static_cast<T>(1.732050808), 1),
+    },
+    {
+      "origin along z",
+      mathfu::Matrix<T, 4, 4>::template LookAt<LH::value>(
+          mathfu::Vector<T, 3>(0, 0, 2), mathfu::Vector<T, 3>(0, 0, 0),
+          mathfu::Vector<T, 3>(0, 1, 0)),
+      mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
+                              0, 1, 0, 0,
+                              0, 0, 1, 0,
+                              0, 0, 0, 1),
+    },
+    {
+      "origin along x",
+      mathfu::Matrix<T, 4, 4>::template LookAt<LH::value>(
+          mathfu::Vector<T, 3>(1, 0, 0), mathfu::Vector<T, 3>(0, 0, 0),
+          mathfu::Vector<T, 3>(0, 1, 0)),
+      mathfu::Matrix<T, 4, 4>(0, 0, 1, 0,
+                              0, 1, 0, 0,
+                              -1, 0, 0, 0,
+                              0, 0, 0, 1),
+    },
+    {
+      "origin along y",
+      mathfu::Matrix<T, 4, 4>::template LookAt<LH::value>(
+          mathfu::Vector<T, 3>(0, 1, 0), mathfu::Vector<T, 3>(0, 0, 0),
+          mathfu::Vector<T, 3>(1, 0, 0)),
+      mathfu::Matrix<T, 4, 4>(0, 1, 0, 0,
+                              0, 0, 1, 0,
+                              1, 0, 0, 0,
+                              0, 0, 0, 1),
+    },
+    {
+      "translated eye, looking along z",
+      mathfu::Matrix<T, 4, 4>::template LookAt<LH::value>(
+          mathfu::Vector<T, 3>(1, 1, 2), mathfu::Vector<T, 3>(1, 1, 1),
+          mathfu::Vector<T, 3>(0, 1, 0)),
+      mathfu::Matrix<T, 4, 4>(1, 0, 0, 0,
+                              0, 1, 0, 0,
+                              0, 0, 1, 0,
+                              -1, -1, -1, 1),
+    },
+  };
   // clang-format on
   VerifyMatrixExpectations(
-      kTestCases, sizeof(kTestCases) / sizeof(kTestCases[0]), precision);
+      kTestCasesRH, sizeof(kTestCasesRH) / sizeof(kTestCasesRH[0]), precision);
+  VerifyMatrixExpectations(
+      kTestCasesLH, sizeof(kTestCasesLH) / sizeof(kTestCasesLH[0]), precision);
 }
 TEST_SCALAR_F(LookAt, FLOAT_PRECISION, kLookAtDoublePrecision)
 

--- a/unit_tests/quaternion_test/quaternion_test.cpp
+++ b/unit_tests/quaternion_test/quaternion_test.cpp
@@ -662,7 +662,8 @@ void RotateFromTo_Test(const T& precision) {
   mathfu::Quaternion<T> arbitrary_to_arbitrary =
       mathfu::Quaternion<T>::RotateFromTo(arbitrary_1, arbitrary_2);
 
-  mathfu::Vector<T, 3> arbitrary_1_to_2 = arbitrary_to_arbitrary.Rotate(arbitrary_1);
+  mathfu::Vector<T, 3> arbitrary_1_to_2 =
+      arbitrary_to_arbitrary.Rotate(arbitrary_1);
   arbitrary_1_to_2.Normalize();
   mathfu::Vector<T, 3> arbitrary_2_normalized = arbitrary_2.Normalized();
 
@@ -735,6 +736,8 @@ template <class T>
 void LookAt_Test(const T& precision) {
   using Quaternion = mathfu::Quaternion<T>;
   using Vector3 = mathfu::Vector<T, 3>;
+  constexpr auto kRH = mathfu::Handedness::kRightHanded;
+  constexpr auto kLH = mathfu::Handedness::kLeftHanded;
   const T one = static_cast<T>(1);
   const T neg_one = static_cast<T>(-1);
   const T zero = static_cast<T>(0);
@@ -744,19 +747,20 @@ void LookAt_Test(const T& precision) {
   // The default forward direction for right-handed coordinates is -Z,
   // and for left-handed coordinates is +Z.
 
-  // ---- Right-handed (default handedness = 1) ----
+  // ---- Right-handed (default) ----
 
   // Looking along -Z (RH default forward) should give identity.
   {
     const Quaternion q =
-        Quaternion::LookAt(Vector3(zero, zero, neg_one), up, one);
+        Quaternion::template LookAt<kRH>(Vector3(zero, zero, neg_one), up);
     EXPECT_NEAR_ORIENTATION(Quaternion::identity, q, epsilon);
   }
 
   // Looking along +Z (opposite of RH default forward) should give a
   // 180-degree rotation around the Y axis.
   {
-    const Quaternion q = Quaternion::LookAt(Vector3(zero, zero, one), up, one);
+    const Quaternion q =
+        Quaternion::template LookAt<kRH>(Vector3(zero, zero, one), up);
     const Quaternion expected =
         Quaternion::FromAngleAxis(static_cast<T>(M_PI), up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
@@ -765,7 +769,8 @@ void LookAt_Test(const T& precision) {
   // Looking along +X should give a 90-degree rotation around Y (turning
   // from -Z forward to +X).
   {
-    const Quaternion q = Quaternion::LookAt(Vector3(one, zero, zero), up, one);
+    const Quaternion q =
+        Quaternion::template LookAt<kRH>(Vector3(one, zero, zero), up);
     const Quaternion expected =
         Quaternion::FromAngleAxis(static_cast<T>(-M_PI / 2), up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
@@ -776,16 +781,16 @@ void LookAt_Test(const T& precision) {
     const Quaternion q_default =
         Quaternion::LookAt(Vector3(one, zero, zero), up);
     const Quaternion q_explicit =
-        Quaternion::LookAt(Vector3(one, zero, zero), up, one);
+        Quaternion::template LookAt<kRH>(Vector3(one, zero, zero), up);
     EXPECT_NEAR_QUAT(q_default, q_explicit, epsilon);
   }
 
-  // ---- Left-handed (handedness = -1) ----
+  // ---- Left-handed ----
 
   // Looking along +Z (LH default forward) should give identity.
   {
     const Quaternion q =
-        Quaternion::LookAt(Vector3(zero, zero, one), up, neg_one);
+        Quaternion::template LookAt<kLH>(Vector3(zero, zero, one), up);
     EXPECT_NEAR_ORIENTATION(Quaternion::identity, q, epsilon);
   }
 
@@ -793,7 +798,7 @@ void LookAt_Test(const T& precision) {
   // 180-degree rotation around the Y axis.
   {
     const Quaternion q =
-        Quaternion::LookAt(Vector3(zero, zero, neg_one), up, neg_one);
+        Quaternion::template LookAt<kLH>(Vector3(zero, zero, neg_one), up);
     const Quaternion expected =
         Quaternion::FromAngleAxis(static_cast<T>(M_PI), up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
@@ -803,7 +808,7 @@ void LookAt_Test(const T& precision) {
   // from +Z forward to +X).
   {
     const Quaternion q =
-        Quaternion::LookAt(Vector3(one, zero, zero), up, neg_one);
+        Quaternion::template LookAt<kLH>(Vector3(one, zero, zero), up);
     const Quaternion expected =
         Quaternion::FromAngleAxis(static_cast<T>(M_PI / 2), up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
@@ -816,7 +821,7 @@ void LookAt_Test(const T& precision) {
   {
     const Vector3 rh_forward(zero, zero, neg_one);
     const Vector3 target(one, zero, zero);
-    const Quaternion q = Quaternion::LookAt(target, up, one);
+    const Quaternion q = Quaternion::template LookAt<kRH>(target, up);
     const Vector3 result = q.Rotate(rh_forward);
     EXPECT_NEAR_VEC3(target, result, epsilon);
   }
@@ -825,7 +830,7 @@ void LookAt_Test(const T& precision) {
   {
     const Vector3 lh_forward(zero, zero, one);
     const Vector3 target(one, zero, zero);
-    const Quaternion q = Quaternion::LookAt(target, up, neg_one);
+    const Quaternion q = Quaternion::template LookAt<kLH>(target, up);
     const Vector3 result = q.Rotate(lh_forward);
     EXPECT_NEAR_VEC3(target, result, epsilon);
   }
@@ -841,11 +846,11 @@ void LookAt_Test(const T& precision) {
         Vector3(one, zero, one).Normalized(),
     };
     for (const auto& dir : directions) {
-      const Quaternion q_rh = Quaternion::LookAt(dir, up, one);
+      const Quaternion q_rh = Quaternion::template LookAt<kRH>(dir, up);
       T length_rh = Quaternion::DotProduct(q_rh, q_rh);
       EXPECT_NEAR(static_cast<T>(1), length_rh, epsilon);
 
-      const Quaternion q_lh = Quaternion::LookAt(dir, up, neg_one);
+      const Quaternion q_lh = Quaternion::template LookAt<kLH>(dir, up);
       T length_lh = Quaternion::DotProduct(q_lh, q_lh);
       EXPECT_NEAR(static_cast<T>(1), length_lh, epsilon);
     }


### PR DESCRIPTION
## Summary
- Adds a `Handedness` enum (`kRightHanded`, `kLeftHanded`) to replace the runtime `float` handedness parameter
- Changes `Matrix::Perspective`, `Matrix::Ortho`, `Matrix::LookAt`, and `Quaternion::LookAt` to accept handedness as a template parameter
- Eliminates unnecessary runtime branching for what is inherently a compile-time decision

## Changes
- Added `enum class Handedness { kRightHanded = 1, kLeftHanded = -1 }` in `matrix.h`
- Changed all helper function signatures (`PerspectiveHelper`, `OrthoHelper`, `LookAtHelper`, `LookAtHelperCalculateAxes`) from `T handedness` parameter to `Handedness H` template parameter
- Updated public API methods to use `template <Handedness H = Handedness::kRightHanded>`
- Updated `Quaternion::LookAt` similarly
- Updated all tests in matrix, quaternion, and frustum test files

## Testing
- All 5319 tests pass (4 pre-existing utilities_NOT_BUILT failures unchanged)
- clang-format applied to all changed files

Closes #140