### PR TITLE
Modernize to C++20: replace workarounds with standard facilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ set(mathfu_dir ${CMAKE_CURRENT_LIST_DIR} CACHE INTERNAL "mathfu directory")
 function(mathfu_configure_flags target)
   set(enable_simd ${mathfu_enable_simd})
 
-  # Require C++17 for inline variables in constants.h.
-  target_compile_features(${target} PRIVATE cxx_std_17)
+  # Require C++20 for concepts and std::numbers.
+  target_compile_features(${target} PRIVATE cxx_std_20)
 
   # Add required includes to the target.
   target_include_directories(${target}

--- a/benchmarks/benchmark_common.h
+++ b/benchmarks/benchmark_common.h
@@ -1,23 +1,24 @@
 /*
-* Copyright 2014 Google Inc. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #ifndef MATHFU_BENCHMARKS_BENCHMARKCOMMON_H_
 #define MATHFU_BENCHMARKS_BENCHMARKCOMMON_H_
 
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #else
 #include <sys/time.h>
@@ -28,9 +29,9 @@
 // This double loop is repeated iterations times to create more accurate
 // performance test.
 #define PERFTEST_2D_VECTOR_LOOP(iterations, size) \
-  for (unsigned int k = 0; k < iterations; k++) \
-  for (unsigned int i = 0; i < size; i++) \
-  for (unsigned int j = 0; j < size; j++)
+  for (unsigned int k = 0; k < iterations; k++)   \
+    for (unsigned int i = 0; i < size; i++)       \
+      for (unsigned int j = 0; j < size; j++)
 
 // High resolution timer.
 class Timer {
@@ -41,14 +42,10 @@ class Timer {
   }
 
   // Save the current number of counter ticks.
-  void Reset() {
-    start_ = GetTicks();
-  }
+  void Reset() { start_ = GetTicks(); }
 
   // Get the time elapsed in counter ticks since Reset() was called.
-  unsigned long long GetElapsedTicks() {
-    return GetTicks() - start_;
-  }
+  unsigned long long GetElapsedTicks() { return GetTicks() - start_; }
 
   // Get the time elapsed in seconds since Reset() was called.
   double GetElapsedSeconds() {
@@ -71,13 +68,11 @@ class Timer {
 #else
     // Use a fixed frequency of 1us to match timeval.
     tick_period_ = 1e-6;
-#endif // defined(_WIN32)
+#endif  // defined(_WIN32)
   }
 
   // Get the period of one counter tick.
-  static double tick_period() {
-    return tick_period_;
-  }
+  static double tick_period() { return tick_period_; }
 
   // Get the number of counter ticks elapsed.
   static unsigned long long GetTicks() {
@@ -88,13 +83,13 @@ class Timer {
 #elif defined(__linux__)
     struct timespec time;
     clock_gettime(CLOCK_MONOTONIC, &time);
-    return (static_cast<unsigned long long>(time.tv_sec) * 1000000000ULL) +
-        time.tv_nsec;
+    return (static_cast<unsigned long long>(time.tv_sec) * 1000000000ULL)
+           + time.tv_nsec;
 #else
     struct timeval time;
     gettimeofday(&time, NULL);
-    return (static_cast<unsigned long long>(time.tv_sec) * 1000000ULL) +
-        time.tv_usec;
+    return (static_cast<unsigned long long>(time.tv_sec) * 1000000ULL)
+           + time.tv_usec;
 #endif
   }
 

--- a/benchmarks/matrix_benchmark/main.cpp
+++ b/benchmarks/matrix_benchmark/main.cpp
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <math.h>
-#include <stdio.h>
-
+#include <cmath>
+#include <cstdio>
 #include <random>
 
 #include "benchmark_common.h"

--- a/benchmarks/vector_benchmark/main.cpp
+++ b/benchmarks/vector_benchmark/main.cpp
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <math.h>
-#include <stdio.h>
-
+#include <cmath>
+#include <cstdio>
 #include <random>
 
 #include "benchmark_common.h"

--- a/include/mathfu/internal/vector_2_simd.h
+++ b/include/mathfu/internal/vector_2_simd.h
@@ -16,7 +16,7 @@
 #ifndef MATHFU_VECTOR_2_SIMD_H_
 #define MATHFU_VECTOR_2_SIMD_H_
 
-#include <math.h>
+#include <cmath>
 
 #include "mathfu/internal/vector_2.h"
 #include "mathfu/utilities.h"

--- a/include/mathfu/internal/vector_3_simd.h
+++ b/include/mathfu/internal/vector_3_simd.h
@@ -16,7 +16,7 @@
 #ifndef MATHFU_VECTOR_3_SIMD_H_
 #define MATHFU_VECTOR_3_SIMD_H_
 
-#include <math.h>
+#include <cmath>
 
 #include "mathfu/internal/vector_3.h"
 #include "mathfu/utilities.h"

--- a/include/mathfu/internal/vector_4_simd.h
+++ b/include/mathfu/internal/vector_4_simd.h
@@ -16,7 +16,7 @@
 #ifndef MATHFU_VECTOR_4_SIMD_H_
 #define MATHFU_VECTOR_4_SIMD_H_
 
-#include <math.h>
+#include <cmath>
 
 #include "mathfu/internal/vector_4.h"
 #include "mathfu/utilities.h"

--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -16,8 +16,7 @@
 #ifndef MATHFU_MATRIX_H_
 #define MATHFU_MATRIX_H_
 
-#include <assert.h>
-
+#include <cassert>
 #include <cmath>
 #include <cstring>
 
@@ -44,10 +43,8 @@
 #pragma warning(disable : 4127)  // conditional expression is constant
 #pragma warning(disable : 4100)  // unreferenced formal parameter
 #pragma warning(disable : 4789)  // buffer overrun
-#if _MSC_VER >= 1900             // MSVC 2015
 #pragma warning(disable : 4456)  // allow shadowing in unrolled loops
 #pragma warning(disable : 4723)  // suppress "potential divide by 0" warning
-#endif                           // _MSC_VER >= 1900
 #endif                           // _MSC_VER
 
 /// @cond MATHFU_INTERNAL

--- a/include/mathfu/quaternion.h
+++ b/include/mathfu/quaternion.h
@@ -16,15 +16,9 @@
 #ifndef MATHFU_QUATERNION_H_
 #define MATHFU_QUATERNION_H_
 
-#ifdef _WIN32
-#if !defined(_USE_MATH_DEFINES)
-#define _USE_MATH_DEFINES  // For M_PI.
-#endif                     // !defined(_USE_MATH_DEFINES)
-#endif                     // _WIN32
-
-#include <math.h>
-
+#include <cmath>
 #include <limits>
+#include <numbers>
 
 #include "mathfu/matrix.h"
 #include "mathfu/vector.h"
@@ -306,10 +300,11 @@ class Quaternion {
     Matrix<T, 3> m(ToMatrix());
     T cos2 = m[0] * m[0] + m[1] * m[1];
     if (cos2 < static_cast<T>(1e-6)) {
-      return Vector<T, 3>(
-          0,
-          m[2] < 0 ? static_cast<T>(0.5 * M_PI) : static_cast<T>(-0.5 * M_PI),
-          -std::atan2(m[3], m[4]));
+      return Vector<T, 3>(0,
+                          m[2] < 0
+                              ? static_cast<T>(0.5) * std::numbers::pi_v<T>
+                              : static_cast<T>(-0.5) * std::numbers::pi_v<T>,
+                          -std::atan2(m[3], m[4]));
     } else {
       return Vector<T, 3>(std::atan2(m[5], m[8]),
                           std::atan2(-m[2], std::sqrt(cos2)),

--- a/include/mathfu/sphere.h
+++ b/include/mathfu/sphere.h
@@ -16,8 +16,8 @@
 #ifndef MATHFU_SPHERE_H_
 #define MATHFU_SPHERE_H_
 
-#define _USE_MATH_DEFINES  // For M_PI.
 #include <cmath>
+#include <numbers>
 
 #include "mathfu/vector.h"
 
@@ -92,7 +92,7 @@ struct Sphere {
   /// @return The area of the circle (pi * r^2).
   inline T Area() const {
     static_assert(N == 2, "Area() is only defined for 2D circles (N=2).");
-    return static_cast<T>(M_PI) * radius * radius;
+    return std::numbers::pi_v<T> * radius * radius;
   }
 
   /// @brief Calculate the volume of a 3D sphere (N=3).
@@ -100,7 +100,7 @@ struct Sphere {
   /// @return The volume of the sphere (4/3 * pi * r^3).
   inline T Volume() const {
     static_assert(N == 3, "Volume() is only defined for 3D spheres (N=3).");
-    return (static_cast<T>(4) / static_cast<T>(3)) * static_cast<T>(M_PI)
+    return (static_cast<T>(4) / static_cast<T>(3)) * std::numbers::pi_v<T>
            * radius * radius * radius;
   }
 

--- a/include/mathfu/utilities.h
+++ b/include/mathfu/utilities.h
@@ -16,13 +16,13 @@
 #ifndef MATHFU_UTILITIES_H_
 #define MATHFU_UTILITIES_H_
 
-#include <assert.h>
-#include <math.h>
-#include <stdint.h>
-#include <stdlib.h>
-
 #include <algorithm>
+#include <cassert>
 #include <climits>
+#include <cmath>
+#include <concepts>
+#include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <type_traits>
 
@@ -307,9 +307,8 @@ bool InRange(T val, T range_start, T range_end) {
 ///
 /// @param x Value to round up. Must be non-negative for signed types.
 /// @returns Value rounded up to the nearest power of 2.
-template <class T>
-typename std::enable_if<std::is_integral<T>::value, T>::type RoundUpToPowerOf2(
-    T x) {
+template <std::integral T>
+T RoundUpToPowerOf2(T x) {
   // Use unsigned arithmetic to avoid undefined behavior with signed shifts.
   typedef typename std::make_unsigned<T>::type U;
   if (x <= 1) return x;
@@ -335,9 +334,8 @@ typename std::enable_if<std::is_integral<T>::value, T>::type RoundUpToPowerOf2(
 ///
 /// @param x Value to round up. Must be non-negative.
 /// @returns Value rounded up to the nearest power of 2.
-template <class T>
-typename std::enable_if<std::is_floating_point<T>::value, T>::type
-RoundUpToPowerOf2(T x) {
+template <std::floating_point T>
+T RoundUpToPowerOf2(T x) {
   if (x <= 0) return x;
   return static_cast<T>(
       pow(static_cast<T>(2), ceil(log(x) / log(static_cast<T>(2)))));
@@ -389,27 +387,14 @@ size_t RoundUpToTypeBoundary(size_t v) {
 /// bytes.
 ///
 /// @param n Size of memory to allocate.
-/// @return Pointer to aligned block of allocated memory or NULL if
+/// @return Pointer to aligned block of allocated memory or nullptr if
 /// allocation failed.
 inline void *AllocateAligned(size_t n) {
-#if defined(_MSC_VER) && _MSC_VER >= 1900  // MSVC 2015
+#if defined(_MSC_VER)
   return _aligned_malloc(n, MATHFU_ALIGNMENT);
 #else
-  // We need to allocate extra bytes to guarantee alignment,
-  // and to store the pointer to the original buffer.
-  uint8_t *buf = reinterpret_cast<uint8_t *>(malloc(n + MATHFU_ALIGNMENT));
-  if (!buf) return NULL;
-  // Align to next higher multiple of MATHFU_ALIGNMENT.
-  uint8_t *aligned_buf = reinterpret_cast<uint8_t *>(
-      (reinterpret_cast<size_t>(buf) + MATHFU_ALIGNMENT)
-      & ~(MATHFU_ALIGNMENT - 1));
-  // Write out original buffer pointer before aligned buffer.
-  // The assert will fail if the allocator granularity is less than the pointer
-  // size, or if MATHFU_ALIGNMENT doesn't fit two pointers.
-  assert(static_cast<size_t>(aligned_buf - buf) >= sizeof(void *));
-  *(reinterpret_cast<uint8_t **>(aligned_buf) - 1) = buf;
-  return aligned_buf;
-#endif  // defined(_MSC_VER) && _MSC_VER >= 1900 // MSVC 2015
+  return std::aligned_alloc(MATHFU_ALIGNMENT, n);
+#endif
 }
 
 /// @brief Deallocate a block of memory allocated with AllocateAligned().
@@ -417,12 +402,11 @@ inline void *AllocateAligned(size_t n) {
 ///
 /// @param p Pointer to memory to deallocate.
 inline void FreeAligned(void *p) {
-#if defined(_MSC_VER) && _MSC_VER >= 1900  // MSVC 2015
+#if defined(_MSC_VER)
   _aligned_free(p);
 #else
-  if (p == NULL) return;
-  free(*(reinterpret_cast<uint8_t **>(p) - 1));
-#endif  // defined(_MSC_VER) && _MSC_VER >= 1900 // MSVC 2015
+  std::free(p);
+#endif
 }
 
 /// @brief SIMD-safe memory allocator, for use with STL types like std::vector.

--- a/include/mathfu/vector.h
+++ b/include/mathfu/vector.h
@@ -16,8 +16,6 @@
 #ifndef MATHFU_VECTOR_H_
 #define MATHFU_VECTOR_H_
 
-#include <math.h>
-
 #include <cmath>
 #include <cstring>
 
@@ -32,9 +30,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4127)  // conditional expression is constant
 #pragma warning(disable : 4100)  // unreferenced formal parameter
-#if _MSC_VER >= 1900             // MSVC 2015
 #pragma warning(disable : 4456)  // allow shadowing in unrolled loops
-#endif                           // _MSC_VER >= 1900
 #endif
 #if defined(__clang__)
 #pragma clang diagnostic push

--- a/unit_tests/frustum_test/frustum_test.cpp
+++ b/unit_tests/frustum_test/frustum_test.cpp
@@ -17,6 +17,7 @@
 
 #include <cmath>
 #include <cstdio>
+#include <numbers>
 
 #include "gtest/gtest.h"
 #include "mathfu/constants.h"
@@ -133,8 +134,8 @@ TEST_FRUSTUM_F(FromViewProjectionOrtho)
 // Test: FromViewProjection with a perspective matrix.
 template <class T>
 void FromViewProjectionPerspective_Test(T precision) {
-  const T fovy = static_cast<T>(M_PI) / static_cast<T>(2);  // 90 degrees
-  const T aspect = static_cast<T>(1);                       // Square viewport
+  const T fovy = std::numbers::pi_v<T> / static_cast<T>(2);  // 90 degrees
+  const T aspect = static_cast<T>(1);                        // Square viewport
   const T near_val = static_cast<T>(1);
   const T far_val = static_cast<T>(100);
 
@@ -394,7 +395,7 @@ TEST_FRUSTUM_F(GetPlane)
 template <class T>
 void PerspectiveCulling_Test(T /*precision*/) {
   // 90-degree FOV, aspect 16:9, near=0.1, far=1000
-  const T fovy = static_cast<T>(M_PI) / static_cast<T>(2);
+  const T fovy = std::numbers::pi_v<T> / static_cast<T>(2);
   const T aspect = static_cast<T>(16) / static_cast<T>(9);
   const T near_val = static_cast<T>(0.1);
   const T far_val = static_cast<T>(1000);

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -16,6 +16,7 @@
 #include "mathfu/matrix.h"
 
 #include <cmath>
+#include <numbers>
 #include <random>
 #include <sstream>
 #include <string>
@@ -655,7 +656,7 @@ TEST_SCALAR_F(Perspective, FLOAT_PRECISION, DOUBLE_PRECISION * 10)
 // and the far plane to z = 1.
 template <class T>
 void PerspectiveOpenGLDepth_Test(const T& precision) {
-  const T fovy = static_cast<T>(M_PI) / 4;  // 45 degrees
+  const T fovy = std::numbers::pi_v<T> / 4;  // 45 degrees
   const T aspect = static_cast<T>(1.5);
   const T znear = static_cast<T>(0.1);
   const T zfar = static_cast<T>(100.0);
@@ -681,7 +682,7 @@ TEST_SCALAR_F(PerspectiveOpenGLDepth, 1e-5f, 1e-10)
 // and the far plane to z = 1.
 template <class T>
 void PerspectiveDirectXDepth_Test(const T& precision) {
-  const T fovy = static_cast<T>(M_PI) / 4;  // 45 degrees
+  const T fovy = std::numbers::pi_v<T> / 4;  // 45 degrees
   const T aspect = static_cast<T>(1.5);
   const T znear = static_cast<T>(0.1);
   const T zfar = static_cast<T>(100.0);
@@ -707,7 +708,7 @@ TEST_SCALAR_F(PerspectiveDirectXDepth, 1e-5f, 1e-10)
 // convention, matching the explicit OpenGL call.
 template <class T>
 void PerspectiveDefaultIsOpenGL_Test(const T& precision) {
-  const T fovy = static_cast<T>(M_PI) / 3;
+  const T fovy = std::numbers::pi_v<T> / 3;
   const T aspect = static_cast<T>(1.6);
   const T znear = static_cast<T>(1.0);
   const T zfar = static_cast<T>(500.0);

--- a/unit_tests/quaternion_test/quaternion_test.cpp
+++ b/unit_tests/quaternion_test/quaternion_test.cpp
@@ -15,7 +15,8 @@
  */
 #include "mathfu/quaternion.h"
 
-#include <math.h>
+#include <cmath>
+#include <numbers>
 
 #include "gtest/gtest.h"
 #include "mathfu/constants.h"
@@ -303,9 +304,9 @@ void Conversion_Test(const T& precision) {
   // Euler Angles, and verify that they match
   mathfu::Quaternion<T> qea(mathfu::Quaternion<T>::FromEulerAngles(angles));
   mathfu::Vector<T, 3> convertedAngles(qea.ToEulerAngles());
-  EXPECT_NEAR(angles[0], M_PI + convertedAngles[0], precision);
-  EXPECT_NEAR(angles[1], M_PI - convertedAngles[1], precision);
-  EXPECT_NEAR(angles[2], M_PI + convertedAngles[2], precision);
+  EXPECT_NEAR(angles[0], std::numbers::pi_v<T> + convertedAngles[0], precision);
+  EXPECT_NEAR(angles[1], std::numbers::pi_v<T> - convertedAngles[1], precision);
+  EXPECT_NEAR(angles[2], std::numbers::pi_v<T> + convertedAngles[2], precision);
   // This will create a Quaternion from Axis Angle, convert back to
   // Axis Angle, and verify that they match.
   mathfu::Vector<T, 3> axis(static_cast<T>(4.3), static_cast<T>(7.6),
@@ -519,8 +520,10 @@ void Dot_Test(const T& precision) {
   mathfu::Vector<T, 3> axis(static_cast<T>(4.3), static_cast<T>(7.6),
                             static_cast<T>(1.2));
   axis.Normalize();
-  T angle1 = static_cast<T>(1.2), angle2 = static_cast<T>(angle1 + M_PI / 2.0),
-    angle3 = static_cast<T>(angle1 + M_PI), angle4 = static_cast<T>(0.7);
+  T angle1 = static_cast<T>(1.2),
+    angle2 = static_cast<T>(angle1 + std::numbers::pi_v<T> / 2),
+    angle3 = static_cast<T>(angle1 + std::numbers::pi_v<T>),
+    angle4 = static_cast<T>(0.7);
   mathfu::Quaternion<T> qaa1(
       mathfu::Quaternion<T>::FromAngleAxis(angle1, axis));
   mathfu::Quaternion<T> qaa2(
@@ -762,7 +765,7 @@ void LookAt_Test(const T& precision) {
     const Quaternion q =
         Quaternion::template LookAt<kRH>(Vector3(zero, zero, one), up);
     const Quaternion expected =
-        Quaternion::FromAngleAxis(static_cast<T>(M_PI), up);
+        Quaternion::FromAngleAxis(std::numbers::pi_v<T>, up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
   }
 
@@ -772,7 +775,7 @@ void LookAt_Test(const T& precision) {
     const Quaternion q =
         Quaternion::template LookAt<kRH>(Vector3(one, zero, zero), up);
     const Quaternion expected =
-        Quaternion::FromAngleAxis(static_cast<T>(-M_PI / 2), up);
+        Quaternion::FromAngleAxis(-std::numbers::pi_v<T> / 2, up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
   }
 
@@ -800,7 +803,7 @@ void LookAt_Test(const T& precision) {
     const Quaternion q =
         Quaternion::template LookAt<kLH>(Vector3(zero, zero, neg_one), up);
     const Quaternion expected =
-        Quaternion::FromAngleAxis(static_cast<T>(M_PI), up);
+        Quaternion::FromAngleAxis(std::numbers::pi_v<T>, up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
   }
 
@@ -810,7 +813,7 @@ void LookAt_Test(const T& precision) {
     const Quaternion q =
         Quaternion::template LookAt<kLH>(Vector3(one, zero, zero), up);
     const Quaternion expected =
-        Quaternion::FromAngleAxis(static_cast<T>(M_PI / 2), up);
+        Quaternion::FromAngleAxis(std::numbers::pi_v<T> / 2, up);
     EXPECT_NEAR_ORIENTATION(expected, q, epsilon);
   }
 

--- a/unit_tests/sphere_test/sphere_test.cpp
+++ b/unit_tests/sphere_test/sphere_test.cpp
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define _USE_MATH_DEFINES  // For M_PI.
 #include "mathfu/sphere.h"
 
 #include <cmath>
+#include <numbers>
 
 #include "gtest/gtest.h"
 #include "mathfu/utilities.h"
@@ -366,7 +366,7 @@ void Area_Test(T precision) {
   mathfu::Vector<T, 2> center(static_cast<T>(0), static_cast<T>(0));
   T radius = static_cast<T>(5);
   mathfu::Sphere<T, 2> circle(center, radius);
-  T expected = static_cast<T>(M_PI) * static_cast<T>(25);
+  T expected = std::numbers::pi_v<T> * static_cast<T>(25);
   EXPECT_NEAR(static_cast<double>(circle.Area()), static_cast<double>(expected),
               static_cast<double>(precision));
 }
@@ -379,7 +379,7 @@ void AreaUnit_Test(T precision) {
   T radius = static_cast<T>(1);
   mathfu::Sphere<T, 2> circle(center, radius);
   EXPECT_NEAR(static_cast<double>(circle.Area()),
-              static_cast<double>(static_cast<T>(M_PI)),
+              static_cast<double>(std::numbers::pi_v<T>),
               static_cast<double>(precision));
 }
 TEST_2D_F(AreaUnit)
@@ -391,7 +391,7 @@ void Volume_Test(T precision) {
                               static_cast<T>(0));
   T radius = static_cast<T>(5);
   mathfu::Sphere<T, 3> sphere(center, radius);
-  T expected = (static_cast<T>(4) / static_cast<T>(3)) * static_cast<T>(M_PI)
+  T expected = (static_cast<T>(4) / static_cast<T>(3)) * std::numbers::pi_v<T>
                * radius * radius * radius;
   EXPECT_NEAR(static_cast<double>(sphere.Volume()),
               static_cast<double>(expected), static_cast<double>(precision));
@@ -405,7 +405,7 @@ void VolumeUnit_Test(T precision) {
                               static_cast<T>(0));
   T radius = static_cast<T>(1);
   mathfu::Sphere<T, 3> sphere(center, radius);
-  T expected = (static_cast<T>(4) / static_cast<T>(3)) * static_cast<T>(M_PI);
+  T expected = (static_cast<T>(4) / static_cast<T>(3)) * std::numbers::pi_v<T>;
   EXPECT_NEAR(static_cast<double>(sphere.Volume()),
               static_cast<double>(expected), static_cast<double>(precision));
 }

--- a/unit_tests/transform_test/transform_test.cpp
+++ b/unit_tests/transform_test/transform_test.cpp
@@ -16,13 +16,10 @@
 #include "mathfu/transform.h"
 
 #include <cmath>
+#include <numbers>
 
 #include "gtest/gtest.h"
 #include "precision.h"
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
 
 namespace {
 
@@ -97,7 +94,7 @@ template <class T>
 void PositionRotationConstruction_Test(T precision) {
   mathfu::Vector<T, 3> pos(T(4), T(5), T(6));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 4), mathfu::Vector<T, 3>(T(0), T(1), T(0)));
+      std::numbers::pi_v<T> / 4, mathfu::Vector<T, 3>(T(0), T(1), T(0)));
   mathfu::Transform<T> t(pos, rot);
   EXPECT_TRUE(NearVector(t.position, pos, precision));
   EXPECT_EQ(t.rotation, rot);
@@ -111,7 +108,7 @@ template <class T>
 void FullConstruction_Test(T precision) {
   mathfu::Vector<T, 3> pos(T(1), T(2), T(3));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 2), mathfu::Vector<T, 3>(T(0), T(0), T(1)));
+      std::numbers::pi_v<T> / 2, mathfu::Vector<T, 3>(T(0), T(0), T(1)));
   mathfu::Vector<T, 3> scl(T(2), T(3), T(4));
   mathfu::Transform<T> t(pos, rot, scl);
   EXPECT_TRUE(NearVector(t.position, pos, precision));
@@ -125,7 +122,7 @@ template <class T>
 void ToMatrix_Test(T precision) {
   mathfu::Vector<T, 3> pos(T(10), T(20), T(30));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 2), mathfu::Vector<T, 3>(T(0), T(1), T(0)));
+      std::numbers::pi_v<T> / 2, mathfu::Vector<T, 3>(T(0), T(1), T(0)));
   mathfu::Vector<T, 3> scl(T(2), T(3), T(4));
   mathfu::Transform<T> t(pos, rot, scl);
 
@@ -144,7 +141,7 @@ void TransformPoint_Test(T precision) {
   // and translates by (10, 0, 0).
   mathfu::Vector<T, 3> pos(T(10), T(0), T(0));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 2), mathfu::Vector<T, 3>(T(0), T(0), T(1)));
+      std::numbers::pi_v<T> / 2, mathfu::Vector<T, 3>(T(0), T(0), T(1)));
   mathfu::Vector<T, 3> scl(T(2), T(1), T(1));
   mathfu::Transform<T> t(pos, rot, scl);
 
@@ -165,7 +162,7 @@ template <class T>
 void TransformDirection_Test(T precision) {
   mathfu::Vector<T, 3> pos(T(100), T(200), T(300));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 2), mathfu::Vector<T, 3>(T(0), T(0), T(1)));
+      std::numbers::pi_v<T> / 2, mathfu::Vector<T, 3>(T(0), T(0), T(1)));
   mathfu::Vector<T, 3> scl(T(2), T(1), T(1));
   mathfu::Transform<T> t(pos, rot, scl);
 
@@ -186,7 +183,7 @@ template <class T>
 void Inverse_Test(T precision) {
   mathfu::Vector<T, 3> pos(T(3), T(-1), T(7));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 3), mathfu::Vector<T, 3>(T(0), T(1), T(0)));
+      std::numbers::pi_v<T> / 3, mathfu::Vector<T, 3>(T(0), T(1), T(0)));
   mathfu::Vector<T, 3> scl(T(2), T(2), T(2));
   mathfu::Transform<T> t(pos, rot, scl);
 
@@ -219,7 +216,7 @@ template <class T>
 void InversePointRoundTrip_Test(T precision) {
   mathfu::Vector<T, 3> pos(T(5), T(-2), T(8));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 6), mathfu::Vector<T, 3>(T(1), T(0), T(0)));
+      std::numbers::pi_v<T> / 6, mathfu::Vector<T, 3>(T(1), T(0), T(0)));
   mathfu::Vector<T, 3> scl(T(3), T(3), T(3));
   mathfu::Transform<T> t(pos, rot, scl);
   mathfu::Transform<T> inv = t.Inverse();
@@ -239,7 +236,7 @@ template <class T>
 void InverseUnitScale_Test(T precision) {
   mathfu::Vector<T, 3> pos(T(10), T(-5), T(3));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 4),
+      std::numbers::pi_v<T> / 4,
       mathfu::Vector<T, 3>(T(1), T(1), T(0)).Normalized());
   mathfu::Transform<T> t(pos, rot);
   mathfu::Transform<T> inv = t.Inverse();
@@ -260,7 +257,7 @@ void Composition_Test(T precision) {
   // Create two transforms and compose them.
   mathfu::Vector<T, 3> pos1(T(1), T(0), T(0));
   mathfu::Quaternion<T> rot1 = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 2), mathfu::Vector<T, 3>(T(0), T(0), T(1)));
+      std::numbers::pi_v<T> / 2, mathfu::Vector<T, 3>(T(0), T(0), T(1)));
   mathfu::Transform<T> t1(pos1, rot1);
 
   mathfu::Vector<T, 3> pos2(T(0), T(1), T(0));
@@ -290,13 +287,13 @@ template <class T>
 void CompositionMatchesMatrix_Test(T precision) {
   mathfu::Vector<T, 3> pos1(T(2), T(-1), T(3));
   mathfu::Quaternion<T> rot1 = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 4), mathfu::Vector<T, 3>(T(0), T(1), T(0)));
+      std::numbers::pi_v<T> / 4, mathfu::Vector<T, 3>(T(0), T(1), T(0)));
   mathfu::Vector<T, 3> scl1(T(2), T(2), T(2));
   mathfu::Transform<T> t1(pos1, rot1, scl1);
 
   mathfu::Vector<T, 3> pos2(T(-1), T(0), T(5));
   mathfu::Quaternion<T> rot2 = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 6), mathfu::Vector<T, 3>(T(1), T(0), T(0)));
+      std::numbers::pi_v<T> / 6, mathfu::Vector<T, 3>(T(1), T(0), T(0)));
   mathfu::Vector<T, 3> scl2(T(3), T(3), T(3));
   mathfu::Transform<T> t2(pos2, rot2, scl2);
 
@@ -331,7 +328,7 @@ void Equality_Test(T precision) {
   (void)precision;
   mathfu::Vector<T, 3> pos(T(1), T(2), T(3));
   mathfu::Quaternion<T> rot = mathfu::Quaternion<T>::FromAngleAxis(
-      static_cast<T>(M_PI / 4), mathfu::Vector<T, 3>(T(0), T(1), T(0)));
+      std::numbers::pi_v<T> / 4, mathfu::Vector<T, 3>(T(0), T(1), T(0)));
   mathfu::Vector<T, 3> scl(T(2), T(3), T(4));
 
   mathfu::Transform<T> t1(pos, rot, scl);


### PR DESCRIPTION
## Summary
- Bump minimum C++ standard from C++17 to C++20
- Replace `_USE_MATH_DEFINES` / `M_PI` with `std::numbers::pi_v<T>` throughout
- Replace `enable_if` SFINAE with C++20 concepts (`std::integral`, `std::floating_point`) in `RoundUpToPowerOf2`
- Simplify `AllocateAligned`/`FreeAligned` by removing pre-MSVC 2015 manual alignment fallback
- Replace deprecated C headers with C++ equivalents
- Remove `_MSC_VER >= 1900` version checks (always true with C++20)
- Add `NOMINMAX` to benchmark header to prevent `windows.h` min/max macro conflicts

## Changes
- **CMakeLists.txt**: `cxx_std_17` → `cxx_std_20`
- **quaternion.h, sphere.h**: Remove `_USE_MATH_DEFINES` hack, use `<numbers>` header
- **utilities.h**: C++20 concepts for `RoundUpToPowerOf2`, simplified aligned allocator, modern C++ headers
- **vector.h, matrix.h**: Remove conditional `_MSC_VER >= 1900` pragma blocks, replace `<math.h>`/`<assert.h>`
- **internal/vector_{2,3,4}_simd.h**: Replace `<math.h>` with `<cmath>`
- **benchmarks/**: Replace C headers, add `NOMINMAX` to prevent macro conflicts
- **unit_tests/**: Replace all `M_PI` usage with `std::numbers::pi_v<T>`, add `<numbers>` includes

## Testing
- All 5319 tests pass (4 pre-existing utilities NOT_BUILT failures unchanged)
- All benchmarks compile successfully
- clang-format applied to all changed files

Closes #143