### PR TITLE
Add missing main() to utilities test

### DIFF
--- a/unit_tests/utilities_test/utilities_test.cpp
+++ b/unit_tests/utilities_test/utilities_test.cpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 
 #include "gtest/gtest.h"
 
@@ -110,4 +111,10 @@ TEST_F(UtilitiesTests, RoundUpToTypeBoundary_VariousTypes) {
     EXPECT_EQ(2u, mathfu::RoundUpToTypeBoundary<int16_t>(2));
     EXPECT_EQ(4u, mathfu::RoundUpToTypeBoundary<int16_t>(3));
   }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  printf("%s (%s)\n", argv[0], MATHFU_BUILD_OPTIONS_STRING);
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Summary
- Fixes the utilities test linker failure caused by a missing `main()` function

## Changes
- Added `main()` function to `utilities_test.cpp` matching the pattern used by all 12 other test files
- Added `#include <cstdio>` for `printf`

## Root Cause
`utilities_test.cpp` was the only test file without an explicit `main()` that calls `::testing::InitGoogleTest()` and `RUN_ALL_TESTS()`. This caused all four utilities test executables (`utilities_tests`, `utilities_simd_padding_tests`, `utilities_simd_no_padding_tests`, `utilities_no_simd_tests`) to fail to link.

## Testing
- All 5347 tests pass (up from 5319, the 28 new tests are from the previously-broken utilities test variants)
- `ctest --output-on-failure -C Release` shows 100% pass rate

Fixes #145