### PR TITLE
Add constexpr support to all eligible functions

### DIFF
--- a/include/mathfu/aabb.h
+++ b/include/mathfu/aabb.h
@@ -48,7 +48,7 @@ struct AABB {
   ///
   /// @param min Minimum corner of the bounding box.
   /// @param max Maximum corner of the bounding box.
-  inline AABB(const Vector<T, N>& min, const Vector<T, N>& max)
+  constexpr AABB(const Vector<T, N>& min, const Vector<T, N>& max)
       : min(min), max(max) {}
 
   /// @brief Create an AABB from a center point and half-extents.
@@ -57,8 +57,8 @@ struct AABB {
   /// @param extents Half-size vector from center to max corner.
   /// @param tag Unused tag parameter to disambiguate from min/max constructor.
   struct FromCenterExtentsTag {};
-  inline AABB(const Vector<T, N>& center, const Vector<T, N>& extents,
-              FromCenterExtentsTag)
+  constexpr AABB(const Vector<T, N>& center, const Vector<T, N>& extents,
+                 FromCenterExtentsTag)
       : min(center - extents), max(center + extents) {}
 
   /// @brief Create an AABB from a center point and half-extents.
@@ -67,36 +67,36 @@ struct AABB {
   /// @param center Center point of the bounding box.
   /// @param extents Half-size vector from center to max corner.
   /// @return A new AABB constructed from center and extents.
-  static inline AABB<T, N> FromCenterExtents(const Vector<T, N>& center,
-                                             const Vector<T, N>& extents) {
+  static constexpr AABB<T, N> FromCenterExtents(const Vector<T, N>& center,
+                                                const Vector<T, N>& extents) {
     return AABB<T, N>(center - extents, center + extents);
   }
 
   /// @brief Calculate the center point of the bounding box.
   ///
   /// @return The center point as a Vector.
-  inline Vector<T, N> Center() const {
+  constexpr Vector<T, N> Center() const {
     return (min + max) * static_cast<T>(0.5);
   }
 
   /// @brief Calculate the half-size (extents) of the bounding box.
   ///
   /// @return The half-size vector from center to max corner.
-  inline Vector<T, N> Extents() const {
+  constexpr Vector<T, N> Extents() const {
     return (max - min) * static_cast<T>(0.5);
   }
 
   /// @brief Calculate the full size of the bounding box.
   ///
   /// @return The size vector (max - min).
-  inline Vector<T, N> Size() const { return max - min; }
+  constexpr Vector<T, N> Size() const { return max - min; }
 
   /// @brief Test whether a point is contained within the AABB.
   ///
   /// The test is inclusive on all boundaries.
   /// @param point The point to test.
   /// @return true if the point is inside or on the boundary of the AABB.
-  inline bool Contains(const Vector<T, N>& point) const {
+  constexpr bool Contains(const Vector<T, N>& point) const {
     for (int i = 0; i < N; ++i) {
       if (point[i] < min[i] || point[i] > max[i]) {
         return false;
@@ -109,7 +109,7 @@ struct AABB {
   ///
   /// @param other The AABB to test.
   /// @return true if other is entirely inside or on the boundary of this AABB.
-  inline bool Contains(const AABB<T, N>& other) const {
+  constexpr bool Contains(const AABB<T, N>& other) const {
     for (int i = 0; i < N; ++i) {
       if (other.min[i] < min[i] || other.max[i] > max[i]) {
         return false;
@@ -122,7 +122,7 @@ struct AABB {
   ///
   /// @param other The AABB to test for overlap.
   /// @return true if the two AABBs overlap (including touching boundaries).
-  inline bool Intersects(const AABB<T, N>& other) const {
+  constexpr bool Intersects(const AABB<T, N>& other) const {
     for (int i = 0; i < N; ++i) {
       if (other.max[i] < min[i] || other.min[i] > max[i]) {
         return false;
@@ -137,7 +137,7 @@ struct AABB {
   /// in one or more dimensions).
   /// @param other The AABB to intersect with.
   /// @return The intersection AABB.
-  inline AABB<T, N> Intersection(const AABB<T, N>& other) const {
+  constexpr AABB<T, N> Intersection(const AABB<T, N>& other) const {
     return AABB<T, N>(Vector<T, N>::Max(min, other.min),
                       Vector<T, N>::Min(max, other.max));
   }
@@ -146,7 +146,7 @@ struct AABB {
   ///
   /// @param other The AABB to union with.
   /// @return The smallest AABB that contains both this and other.
-  inline AABB<T, N> Union(const AABB<T, N>& other) const {
+  constexpr AABB<T, N> Union(const AABB<T, N>& other) const {
     return AABB<T, N>(Vector<T, N>::Min(min, other.min),
                       Vector<T, N>::Max(max, other.max));
   }
@@ -154,7 +154,7 @@ struct AABB {
   /// @brief Expand this AABB to include a point.
   ///
   /// @param point The point to include.
-  inline void Expand(const Vector<T, N>& point) {
+  constexpr void Expand(const Vector<T, N>& point) {
     min = Vector<T, N>::Min(min, point);
     max = Vector<T, N>::Max(max, point);
   }
@@ -162,7 +162,7 @@ struct AABB {
   /// @brief Expand this AABB to include another AABB.
   ///
   /// @param other The AABB to include.
-  inline void Expand(const AABB<T, N>& other) {
+  constexpr void Expand(const AABB<T, N>& other) {
     min = Vector<T, N>::Min(min, other.min);
     max = Vector<T, N>::Max(max, other.max);
   }
@@ -175,7 +175,7 @@ struct AABB {
 /// @param b Second AABB to compare.
 /// @return true if both min and max corners are equal.
 template <class T, int N>
-inline bool operator==(const AABB<T, N>& a, const AABB<T, N>& b) {
+constexpr bool operator==(const AABB<T, N>& a, const AABB<T, N>& b) {
   return (a.min == b.min && a.max == b.max);
 }
 
@@ -185,7 +185,7 @@ inline bool operator==(const AABB<T, N>& a, const AABB<T, N>& b) {
 /// @param b Second AABB to compare.
 /// @return true if the AABBs differ.
 template <class T, int N>
-inline bool operator!=(const AABB<T, N>& a, const AABB<T, N>& b) {
+constexpr bool operator!=(const AABB<T, N>& a, const AABB<T, N>& b) {
   return !(a == b);
 }
 

--- a/include/mathfu/capsule.h
+++ b/include/mathfu/capsule.h
@@ -47,7 +47,8 @@ struct Capsule {
   /// @param start The start endpoint of the capsule's line segment.
   /// @param end The end endpoint of the capsule's line segment.
   /// @param radius The radius of the capsule.
-  inline Capsule(const Vector<T, N>& start, const Vector<T, N>& end, T radius)
+  constexpr Capsule(const Vector<T, N>& start, const Vector<T, N>& end,
+                    T radius)
       : start(start), end(end), radius(radius) {}
 
   /// @brief Calculate the center of the capsule.
@@ -55,7 +56,7 @@ struct Capsule {
   /// The center is the midpoint of the start and end endpoints.
   ///
   /// @return The center point of the capsule.
-  inline Vector<T, N> Center() const {
+  constexpr Vector<T, N> Center() const {
     return (start + end) * static_cast<T>(0.5);
   }
 
@@ -73,7 +74,7 @@ struct Capsule {
   ///
   /// @param point The point to test.
   /// @return true if the point is inside the capsule, false otherwise.
-  inline bool Contains(const Vector<T, N>& point) const {
+  constexpr bool Contains(const Vector<T, N>& point) const {
     const Vector<T, N> closest = ClosestPointOnSegment(point, start, end);
     return Vector<T, N>::DistanceSquared(point, closest) <= radius * radius;
   }
@@ -85,7 +86,7 @@ struct Capsule {
   /// @param seg_start The start of the line segment.
   /// @param seg_end The end of the line segment.
   /// @return The closest point on the segment to the query point.
-  static inline Vector<T, N> ClosestPointOnSegment(
+  static constexpr Vector<T, N> ClosestPointOnSegment(
       const Vector<T, N>& point, const Vector<T, N>& seg_start,
       const Vector<T, N>& seg_end) {
     const Vector<T, N> segment = seg_end - seg_start;
@@ -106,7 +107,7 @@ struct Capsule {
 /// @param c1 Capsule to be tested.
 /// @param c2 Other capsule to be tested.
 template <class T, int N>
-bool operator==(const Capsule<T, N>& c1, const Capsule<T, N>& c2) {
+constexpr bool operator==(const Capsule<T, N>& c1, const Capsule<T, N>& c2) {
   return (c1.start == c2.start && c1.end == c2.end && c1.radius == c2.radius);
 }
 
@@ -115,7 +116,7 @@ bool operator==(const Capsule<T, N>& c1, const Capsule<T, N>& c2) {
 /// @param c1 Capsule to be tested.
 /// @param c2 Other capsule to be tested.
 template <class T, int N>
-bool operator!=(const Capsule<T, N>& c1, const Capsule<T, N>& c2) {
+constexpr bool operator!=(const Capsule<T, N>& c1, const Capsule<T, N>& c2) {
   return !(c1 == c2);
 }
 

--- a/include/mathfu/constants.h
+++ b/include/mathfu/constants.h
@@ -90,75 +90,75 @@ inline const Vector<float, 4> kAxisZ4f(0.0f, 0.0f, 1.0f, 0.0f);
 inline const Vector<float, 4> kAxisW4f(0.0f, 0.0f, 0.0f, 1.0f);
 
 /// 2-dimensional <code>double</code> Vector of zeros.
-inline const Vector<double, 2> kZeros2d(0.0, 0.0);
+inline constexpr Vector<double, 2> kZeros2d(0.0, 0.0);
 /// 2-dimensional <code>double</code> Vector of ones.
-inline const Vector<double, 2> kOnes2d(1.0, 1.0);
+inline constexpr Vector<double, 2> kOnes2d(1.0, 1.0);
 /// 2-dimensional <code>double</code> unit Vector pointing along the X axis.
-inline const Vector<double, 2> kAxisX2d(1.0, 0.0);
+inline constexpr Vector<double, 2> kAxisX2d(1.0, 0.0);
 /// 2-dimensional <code>double</code> unit Vector pointing along the Y axis.
-inline const Vector<double, 2> kAxisY2d(0.0, 1.0);
+inline constexpr Vector<double, 2> kAxisY2d(0.0, 1.0);
 
 /// 3-dimensional <code>double</code> Vector of zeros.
-inline const Vector<double, 3> kZeros3d(0.0, 0.0, 0.0);
+inline constexpr Vector<double, 3> kZeros3d(0.0, 0.0, 0.0);
 /// 3-dimensional <code>double</code> Vector of ones.
-inline const Vector<double, 3> kOnes3d(1.0, 1.0, 1.0);
+inline constexpr Vector<double, 3> kOnes3d(1.0, 1.0, 1.0);
 /// 3-dimensional <code>double</code> unit Vector pointing along the X axis.
-inline const Vector<double, 3> kAxisX3d(1.0, 0.0, 0.0);
+inline constexpr Vector<double, 3> kAxisX3d(1.0, 0.0, 0.0);
 /// 3-dimensional <code>double</code> unit Vector pointing along the Y axis.
-inline const Vector<double, 3> kAxisY3d(0.0, 1.0, 0.0);
+inline constexpr Vector<double, 3> kAxisY3d(0.0, 1.0, 0.0);
 /// 3-dimensional <code>double</code> unit Vector pointing along the Z axis.
-inline const Vector<double, 3> kAxisZ3d(0.0, 0.0, 1.0);
+inline constexpr Vector<double, 3> kAxisZ3d(0.0, 0.0, 1.0);
 
 /// 4-dimensional <code>double</code> Vector of zeros.
-inline const Vector<double, 4> kZeros4d(0.0, 0.0, 0.0, 0.0);
+inline constexpr Vector<double, 4> kZeros4d(0.0, 0.0, 0.0, 0.0);
 /// 4-dimensional <code>double</code> Vector of ones.
-inline const Vector<double, 4> kOnes4d(1.0, 1.0, 1.0, 1.0);
+inline constexpr Vector<double, 4> kOnes4d(1.0, 1.0, 1.0, 1.0);
 /// 4-dimensional <code>double</code> unit Vector pointing along the X axis.
-inline const Vector<double, 4> kAxisX4d(1.0, 0.0, 0.0, 0.0);
+inline constexpr Vector<double, 4> kAxisX4d(1.0, 0.0, 0.0, 0.0);
 /// 4-dimensional <code>double</code> unit Vector pointing along the Y axis.
-inline const Vector<double, 4> kAxisY4d(0.0, 1.0, 0.0, 0.0);
+inline constexpr Vector<double, 4> kAxisY4d(0.0, 1.0, 0.0, 0.0);
 /// 4-dimensional <code>double</code> unit Vector pointing along the Z axis.
-inline const Vector<double, 4> kAxisZ4d(0.0, 0.0, 1.0, 0.0);
+inline constexpr Vector<double, 4> kAxisZ4d(0.0, 0.0, 1.0, 0.0);
 /// 4-dimensional <code>double</code> unit Vector pointing along the W axis.
-inline const Vector<double, 4> kAxisW4d(0.0, 0.0, 0.0, 1.0);
+inline constexpr Vector<double, 4> kAxisW4d(0.0, 0.0, 0.0, 1.0);
 
 /// 2-dimensional <code>int</code> Vector of ones.
-inline const Vector<int, 2> kOnes2i(1, 1);
+inline constexpr Vector<int, 2> kOnes2i(1, 1);
 /// 2-dimensional <code>int</code> Vector of zeros.
-inline const Vector<int, 2> kZeros2i(0, 0);
+inline constexpr Vector<int, 2> kZeros2i(0, 0);
 /// 2-dimensional <code>int</code> unit Vector pointing along the X axis.
-inline const Vector<int, 2> kAxisX2i(1, 0);
+inline constexpr Vector<int, 2> kAxisX2i(1, 0);
 /// 2-dimensional <code>int</code> unit Vector pointing along the Y axis.
-inline const Vector<int, 2> kAxisY2i(0, 1);
+inline constexpr Vector<int, 2> kAxisY2i(0, 1);
 
 /// 3-dimensional <code>int</code> Vector of zeros.
-inline const Vector<int, 3> kZeros3i(0, 0, 0);
+inline constexpr Vector<int, 3> kZeros3i(0, 0, 0);
 /// 3-dimensional <code>int</code> Vector of ones.
-inline const Vector<int, 3> kOnes3i(1, 1, 1);
+inline constexpr Vector<int, 3> kOnes3i(1, 1, 1);
 /// 3-dimensional <code>int</code> unit Vector pointing along the X axis.
-inline const Vector<int, 3> kAxisX3i(1, 0, 0);
+inline constexpr Vector<int, 3> kAxisX3i(1, 0, 0);
 /// 3-dimensional <code>int</code> unit Vector pointing along the Y axis.
-inline const Vector<int, 3> kAxisY3i(0, 1, 0);
+inline constexpr Vector<int, 3> kAxisY3i(0, 1, 0);
 /// 3-dimensional <code>int</code> unit Vector pointing along the Z axis.
-inline const Vector<int, 3> kAxisZ3i(0, 0, 1);
+inline constexpr Vector<int, 3> kAxisZ3i(0, 0, 1);
 
 /// 4-dimensional <code>int</code> Vector of zeros.
-inline const Vector<int, 4> kZeros4i(0, 0, 0, 0);
+inline constexpr Vector<int, 4> kZeros4i(0, 0, 0, 0);
 /// 4-dimensional <code>int</code> Vector of ones.
-inline const Vector<int, 4> kOnes4i(1, 1, 1, 1);
+inline constexpr Vector<int, 4> kOnes4i(1, 1, 1, 1);
 /// 4-dimensional <code>int</code> unit Vector pointing along the X axis.
-inline const Vector<int, 4> kAxisX4i(1, 0, 0, 0);
+inline constexpr Vector<int, 4> kAxisX4i(1, 0, 0, 0);
 /// 4-dimensional <code>int</code> unit Vector pointing along the Y axis.
-inline const Vector<int, 4> kAxisY4i(0, 1, 0, 0);
+inline constexpr Vector<int, 4> kAxisY4i(0, 1, 0, 0);
 /// 4-dimensional <code>int</code> unit Vector pointing along the Z axis.
-inline const Vector<int, 4> kAxisZ4i(0, 0, 1, 0);
+inline constexpr Vector<int, 4> kAxisZ4i(0, 0, 1, 0);
 /// 4-dimensional <code>int</code> unit Vector pointing along the W axis.
-inline const Vector<int, 4> kAxisW4i(0, 0, 0, 1);
+inline constexpr Vector<int, 4> kAxisW4i(0, 0, 0, 1);
 
 /// Quaternion Identity
 inline const Quaternion<float> kQuatIdentityf(1.0f, 0.0f, 0.0f, 0.0f);
 /// Quaternion Identity
-inline const Quaternion<double> kQuatIdentityd(1.0, 0.0, 0.0, 0.0);
+inline constexpr Quaternion<double> kQuatIdentityd(1.0, 0.0, 0.0, 0.0);
 
 // An AffineTransform versoin of the mat4 Identity matrix.
 inline const AffineTransform kAffineIdentity(1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,

--- a/include/mathfu/frustum.h
+++ b/include/mathfu/frustum.h
@@ -67,9 +67,9 @@ struct Frustum {
   /// @param right_plane The right clipping plane.
   /// @param top_plane The top clipping plane.
   /// @param bottom_plane The bottom clipping plane.
-  inline Frustum(const Plane<T>& near_plane, const Plane<T>& far_plane,
-                 const Plane<T>& left_plane, const Plane<T>& right_plane,
-                 const Plane<T>& top_plane, const Plane<T>& bottom_plane) {
+  constexpr Frustum(const Plane<T>& near_plane, const Plane<T>& far_plane,
+                    const Plane<T>& left_plane, const Plane<T>& right_plane,
+                    const Plane<T>& top_plane, const Plane<T>& bottom_plane) {
     planes[kNear] = near_plane;
     planes[kFar] = far_plane;
     planes[kLeft] = left_plane;
@@ -133,7 +133,7 @@ struct Frustum {
   ///
   /// @param point The point to test.
   /// @return true if the point is inside or on the boundary of the frustum.
-  inline bool ContainsPoint(const Vector<T, 3>& point) const {
+  constexpr bool ContainsPoint(const Vector<T, 3>& point) const {
     for (int i = 0; i < kPlaneCount; ++i) {
       if (planes[i].SignedDistance(point) < static_cast<T>(0)) {
         return false;
@@ -151,7 +151,7 @@ struct Frustum {
   ///
   /// @param aabb The axis-aligned bounding box to test.
   /// @return true if the AABB intersects or is inside the frustum.
-  inline bool IntersectsAABB(const AABB<T, 3>& aabb) const {
+  constexpr bool IntersectsAABB(const AABB<T, 3>& aabb) const {
     for (int i = 0; i < kPlaneCount; ++i) {
       // Find the positive vertex: for each axis, pick the component of min
       // or max that is most in the direction of the plane normal.
@@ -175,7 +175,7 @@ struct Frustum {
   ///
   /// @param sphere The sphere to test.
   /// @return true if the sphere intersects or is inside the frustum.
-  inline bool IntersectsSphere(const Sphere<T, 3>& sphere) const {
+  constexpr bool IntersectsSphere(const Sphere<T, 3>& sphere) const {
     for (int i = 0; i < kPlaneCount; ++i) {
       if (planes[i].SignedDistance(sphere.center) < -sphere.radius) {
         return false;
@@ -188,7 +188,7 @@ struct Frustum {
   ///
   /// @param p The plane index to retrieve.
   /// @return Const reference to the requested plane.
-  inline const Plane<T>& GetPlane(FrustumPlane p) const { return planes[p]; }
+  constexpr const Plane<T>& GetPlane(FrustumPlane p) const { return planes[p]; }
 
  private:
   /// @brief Create a normalized Plane from raw (a, b, c, d) coefficients.
@@ -211,7 +211,7 @@ struct Frustum {
 /// @param f1 Frustum to be tested.
 /// @param f2 Other frustum to be tested.
 template <class T>
-bool operator==(const Frustum<T>& f1, const Frustum<T>& f2) {
+constexpr bool operator==(const Frustum<T>& f1, const Frustum<T>& f2) {
   for (int i = 0; i < Frustum<T>::kPlaneCount; ++i) {
     if (f1.planes[i] != f2.planes[i]) {
       return false;
@@ -225,7 +225,7 @@ bool operator==(const Frustum<T>& f1, const Frustum<T>& f2) {
 /// @param f1 Frustum to be tested.
 /// @param f2 Other frustum to be tested.
 template <class T>
-bool operator!=(const Frustum<T>& f1, const Frustum<T>& f2) {
+constexpr bool operator!=(const Frustum<T>& f1, const Frustum<T>& f2) {
   return !(f1 == f2);
 }
 

--- a/include/mathfu/internal/vector_2.h
+++ b/include/mathfu/internal/vector_2.h
@@ -27,40 +27,40 @@ class Vector<T, 2> {
   static const int Dims = 2;
   static const int kDims = 2;
 
-  inline Vector() {}
+  constexpr Vector() {}
 
-  inline Vector(const Vector<T, 2>& v) : x(v.x), y(v.y) {}
+  constexpr Vector(const Vector<T, 2>& v) : x(v.x), y(v.y) {}
 
-  explicit inline Vector(const VectorPacked<T, 2>& v) : x(v.x), y(v.y) {}
+  explicit constexpr Vector(const VectorPacked<T, 2>& v) : x(v.x), y(v.y) {}
 
-  explicit inline Vector(const T* a) : x(a[0]), y(a[1]) {}
+  explicit constexpr Vector(const T* a) : x(a[0]), y(a[1]) {}
 
-  explicit inline Vector(T s) : x(s), y(s) {}
+  explicit constexpr Vector(T s) : x(s), y(s) {}
 
-  inline Vector(T s1, T s2) : x(s1), y(s2) {}
+  constexpr Vector(T s1, T s2) : x(s1), y(s2) {}
 
   template <typename U>
-  explicit inline Vector(const Vector<U, 2>& v)
+  explicit constexpr Vector(const Vector<U, 2>& v)
       : x(static_cast<T>(v.x)), y(static_cast<T>(v.y)) {}
 
-  inline T& operator()(const int i) { return data_[i]; }
+  constexpr T& operator()(const int i) { return data_[i]; }
 
-  inline const T& operator()(const int i) const { return data_[i]; }
+  constexpr const T& operator()(const int i) const { return data_[i]; }
 
-  inline T& operator[](const int i) { return data_[i]; }
+  constexpr T& operator[](const int i) { return data_[i]; }
 
-  inline const T& operator[](const int i) const { return data_[i]; }
+  constexpr const T& operator[](const int i) const { return data_[i]; }
 
-  inline Vector<T, 2> xy() { return Vector<T, 2>(x, y); }
+  constexpr Vector<T, 2> xy() { return Vector<T, 2>(x, y); }
 
-  inline const Vector<T, 2> xy() const { return Vector<T, 2>(x, y); }
+  constexpr const Vector<T, 2> xy() const { return Vector<T, 2>(x, y); }
 
-  inline void Pack(VectorPacked<T, 2>* const vector) const {
+  constexpr void Pack(VectorPacked<T, 2>* const vector) const {
     vector->x = x;
     vector->y = y;
   }
 
-  inline T LengthSquared() const { return LengthSquaredHelper(*this); }
+  constexpr T LengthSquared() const { return LengthSquaredHelper(*this); }
 
   inline T Length() const { return LengthHelper(*this); }
 
@@ -78,39 +78,39 @@ class Vector<T, 2> {
     return ToTypeHelper<T, Dims, CompatibleT>(v);
   }
 
-  static inline T DotProduct(const Vector<T, 2>& v1, const Vector<T, 2>& v2) {
+  static constexpr T DotProduct(const Vector<T, 2>& v1,
+                                const Vector<T, 2>& v2) {
     return DotProductHelper(v1, v2);
   }
 
-  static inline Vector<T, 2> HadamardProduct(const Vector<T, 2>& v1,
-                                             const Vector<T, 2>& v2) {
+  static constexpr Vector<T, 2> HadamardProduct(const Vector<T, 2>& v1,
+                                                const Vector<T, 2>& v2) {
     return HadamardProductHelper(v1, v2);
   }
 
-  static inline Vector<T, 2> HadamardDivide(const Vector<T, 2>& v1,
-                                            const Vector<T, 2>& v2) {
+  static constexpr Vector<T, 2> HadamardDivide(const Vector<T, 2>& v1,
+                                               const Vector<T, 2>& v2) {
     return HadamardDivideHelper(v1, v2);
   }
 
-  static inline Vector<T, 2> Lerp(const Vector<T, 2>& v1,
-                                  const Vector<T, 2>& v2, const T percent) {
+  static constexpr Vector<T, 2> Lerp(const Vector<T, 2>& v1,
+                                     const Vector<T, 2>& v2, const T percent) {
     return LerpHelper(v1, v2, percent);
   }
 
-  static inline bool InRange(const Vector<T, 2>& val,
-                             const Vector<T, 2>& range_start,
-                             const Vector<T, 2>& range_end) {
+  static constexpr bool InRange(const Vector<T, 2>& val,
+                                const Vector<T, 2>& range_start,
+                                const Vector<T, 2>& range_end) {
     return InRangeHelper(val, range_start, range_end);
   }
 
-
-  static inline Vector<T, 2> Max(const Vector<T, 2>& v1,
-                                 const Vector<T, 2>& v2) {
+  static constexpr Vector<T, 2> Max(const Vector<T, 2>& v1,
+                                    const Vector<T, 2>& v2) {
     return MaxHelper(v1, v2);
   }
 
-  static inline Vector<T, 2> Min(const Vector<T, 2>& v1,
-                                 const Vector<T, 2>& v2) {
+  static constexpr Vector<T, 2> Min(const Vector<T, 2>& v1,
+                                    const Vector<T, 2>& v2) {
     return MinHelper(v1, v2);
   }
 
@@ -118,13 +118,13 @@ class Vector<T, 2> {
     return (v1 - v2).Length();
   }
 
-  static inline T DistanceSquared(const Vector<T, 2>& v1,
-                                  const Vector<T, 2>& v2) {
+  static constexpr T DistanceSquared(const Vector<T, 2>& v1,
+                                     const Vector<T, 2>& v2) {
     return (v1 - v2).LengthSquared();
   }
 
-  static inline T CrossProduct(const Vector<T, 2>& v1,
-                               const Vector<T, 2>& v2) {
+  static constexpr T CrossProduct(const Vector<T, 2>& v1,
+                                  const Vector<T, 2>& v2) {
     return CrossProductHelper(v1, v2);
   }
 
@@ -132,18 +132,18 @@ class Vector<T, 2> {
     return AngleHelper(v1, v2);
   }
 
-  static inline Vector<T, 2> Project(const Vector<T, 2>& v,
-                                     const Vector<T, 2>& onto) {
+  static constexpr Vector<T, 2> Project(const Vector<T, 2>& v,
+                                        const Vector<T, 2>& onto) {
     return ProjectHelper(v, onto);
   }
 
-  static inline Vector<T, 2> Reject(const Vector<T, 2>& v,
-                                    const Vector<T, 2>& from) {
+  static constexpr Vector<T, 2> Reject(const Vector<T, 2>& v,
+                                       const Vector<T, 2>& from) {
     return RejectHelper(v, from);
   }
 
-  static inline Vector<T, 2> Reflect(const Vector<T, 2>& incident,
-                                     const Vector<T, 2>& normal) {
+  static constexpr Vector<T, 2> Reflect(const Vector<T, 2>& incident,
+                                        const Vector<T, 2>& normal) {
     return ReflectHelper(incident, normal);
   }
 

--- a/include/mathfu/internal/vector_3.h
+++ b/include/mathfu/internal/vector_3.h
@@ -27,50 +27,50 @@ class Vector<T, 3> {
   static const int Dims = 3;
   static const int kDims = 3;
 
-  inline Vector() {}
+  constexpr Vector() {}
 
-  inline Vector(const Vector<T, 3>& v) : x(v.x), y(v.y), z(v.z) {}
+  constexpr Vector(const Vector<T, 3>& v) : x(v.x), y(v.y), z(v.z) {}
 
-  explicit inline Vector(const VectorPacked<T, 3>& v)
+  explicit constexpr Vector(const VectorPacked<T, 3>& v)
       : x(v.x), y(v.y), z(v.z) {}
 
-  explicit inline Vector(const T* a) : x(a[0]), y(a[1]), z(a[2]) {}
+  explicit constexpr Vector(const T* a) : x(a[0]), y(a[1]), z(a[2]) {}
 
-  explicit inline Vector(T s) : x(s), y(s), z(s) {}
+  explicit constexpr Vector(T s) : x(s), y(s), z(s) {}
 
-  inline Vector(T s1, T s2, T s3) : x(s1), y(s2), z(s3) {}
+  constexpr Vector(T s1, T s2, T s3) : x(s1), y(s2), z(s3) {}
 
-  inline Vector(const Vector<T, 2>& v12, T s3) : x(v12.x), y(v12.y), z(s3) {}
+  constexpr Vector(const Vector<T, 2>& v12, T s3) : x(v12.x), y(v12.y), z(s3) {}
 
   template <typename U>
-  explicit inline Vector(const Vector<U, 3>& v)
+  explicit constexpr Vector(const Vector<U, 3>& v)
       : x(static_cast<T>(v.x)),
         y(static_cast<T>(v.y)),
         z(static_cast<T>(v.z)) {}
 
-  inline T& operator()(const int i) { return data_[i]; }
+  constexpr T& operator()(const int i) { return data_[i]; }
 
-  inline const T& operator()(const int i) const { return data_[i]; }
+  constexpr const T& operator()(const int i) const { return data_[i]; }
 
-  inline T& operator[](const int i) { return data_[i]; }
+  constexpr T& operator[](const int i) { return data_[i]; }
 
-  inline const T& operator[](const int i) const { return data_[i]; }
+  constexpr const T& operator[](const int i) const { return data_[i]; }
 
-  inline Vector<T, 3> xyz() { return Vector<T, 3>(x, y, z); }
+  constexpr Vector<T, 3> xyz() { return Vector<T, 3>(x, y, z); }
 
-  inline const Vector<T, 3> xyz() const { return Vector<T, 3>(x, y, z); }
+  constexpr const Vector<T, 3> xyz() const { return Vector<T, 3>(x, y, z); }
 
-  inline Vector<T, 2> xy() { return Vector<T, 2>(x, y); }
+  constexpr Vector<T, 2> xy() { return Vector<T, 2>(x, y); }
 
-  inline const Vector<T, 2> xy() const { return Vector<T, 2>(x, y); }
+  constexpr const Vector<T, 2> xy() const { return Vector<T, 2>(x, y); }
 
-  inline void Pack(VectorPacked<T, 3>* const vector) const {
+  constexpr void Pack(VectorPacked<T, 3>* const vector) const {
     vector->x = x;
     vector->y = y;
     vector->z = z;
   }
 
-  inline T LengthSquared() const { return LengthSquaredHelper(*this); }
+  constexpr T LengthSquared() const { return LengthSquaredHelper(*this); }
 
   inline T Length() const { return LengthHelper(*this); }
 
@@ -88,44 +88,44 @@ class Vector<T, 3> {
     return ToTypeHelper<T, Dims, CompatibleT>(v);
   }
 
-  static inline T DotProduct(const Vector<T, 3>& v1, const Vector<T, 3>& v2) {
+  static constexpr T DotProduct(const Vector<T, 3>& v1,
+                                const Vector<T, 3>& v2) {
     return DotProductHelper(v1, v2);
   }
 
-  static inline Vector<T, 3> HadamardProduct(const Vector<T, 3>& v1,
-                                             const Vector<T, 3>& v2) {
+  static constexpr Vector<T, 3> HadamardProduct(const Vector<T, 3>& v1,
+                                                const Vector<T, 3>& v2) {
     return HadamardProductHelper(v1, v2);
   }
 
-  static inline Vector<T, 3> HadamardDivide(const Vector<T, 3>& v1,
-                                            const Vector<T, 3>& v2) {
+  static constexpr Vector<T, 3> HadamardDivide(const Vector<T, 3>& v1,
+                                               const Vector<T, 3>& v2) {
     return HadamardDivideHelper(v1, v2);
   }
 
-  static inline Vector<T, 3> CrossProduct(const Vector<T, 3>& v1,
-                                          const Vector<T, 3>& v2) {
+  static constexpr Vector<T, 3> CrossProduct(const Vector<T, 3>& v1,
+                                             const Vector<T, 3>& v2) {
     return CrossProductHelper(v1, v2);
   }
 
-  static inline Vector<T, 3> Lerp(const Vector<T, 3>& v1,
-                                  const Vector<T, 3>& v2, const T percent) {
+  static constexpr Vector<T, 3> Lerp(const Vector<T, 3>& v1,
+                                     const Vector<T, 3>& v2, const T percent) {
     return LerpHelper(v1, v2, percent);
   }
 
-  static inline bool InRange(const Vector<T, 3>& val,
-                             const Vector<T, 3>& range_start,
-                             const Vector<T, 3>& range_end) {
+  static constexpr bool InRange(const Vector<T, 3>& val,
+                                const Vector<T, 3>& range_start,
+                                const Vector<T, 3>& range_end) {
     return InRangeHelper(val, range_start, range_end);
   }
 
-
-  static inline Vector<T, 3> Max(const Vector<T, 3>& v1,
-                                 const Vector<T, 3>& v2) {
+  static constexpr Vector<T, 3> Max(const Vector<T, 3>& v1,
+                                    const Vector<T, 3>& v2) {
     return MaxHelper(v1, v2);
   }
 
-  static inline Vector<T, 3> Min(const Vector<T, 3>& v1,
-                                 const Vector<T, 3>& v2) {
+  static constexpr Vector<T, 3> Min(const Vector<T, 3>& v1,
+                                    const Vector<T, 3>& v2) {
     return MinHelper(v1, v2);
   }
 
@@ -133,8 +133,8 @@ class Vector<T, 3> {
     return (v1 - v2).Length();
   }
 
-  static inline T DistanceSquared(const Vector<T, 3>& v1,
-                                  const Vector<T, 3>& v2) {
+  static constexpr T DistanceSquared(const Vector<T, 3>& v1,
+                                     const Vector<T, 3>& v2) {
     return (v1 - v2).LengthSquared();
   }
 
@@ -142,18 +142,18 @@ class Vector<T, 3> {
     return AngleHelper(v1, v2);
   }
 
-  static inline Vector<T, 3> Project(const Vector<T, 3>& v,
-                                     const Vector<T, 3>& onto) {
+  static constexpr Vector<T, 3> Project(const Vector<T, 3>& v,
+                                        const Vector<T, 3>& onto) {
     return ProjectHelper(v, onto);
   }
 
-  static inline Vector<T, 3> Reject(const Vector<T, 3>& v,
-                                    const Vector<T, 3>& from) {
+  static constexpr Vector<T, 3> Reject(const Vector<T, 3>& v,
+                                       const Vector<T, 3>& from) {
     return RejectHelper(v, from);
   }
 
-  static inline Vector<T, 3> Reflect(const Vector<T, 3>& incident,
-                                     const Vector<T, 3>& normal) {
+  static constexpr Vector<T, 3> Reflect(const Vector<T, 3>& incident,
+                                        const Vector<T, 3>& normal) {
     return ReflectHelper(incident, normal);
   }
 

--- a/include/mathfu/internal/vector_4.h
+++ b/include/mathfu/internal/vector_4.h
@@ -28,60 +28,60 @@ class Vector<T, 4> {
   static const int Dims = 4;
   static const int kDims = 4;
 
-  inline Vector() {}
+  constexpr Vector() {}
 
-  inline Vector(const Vector<T, 4>& v) : x(v.x), y(v.y), z(v.z), w(v.w) {}
+  constexpr Vector(const Vector<T, 4>& v) : x(v.x), y(v.y), z(v.z), w(v.w) {}
 
-  explicit inline Vector(const VectorPacked<T, 4>& v)
+  explicit constexpr Vector(const VectorPacked<T, 4>& v)
       : x(v.x), y(v.y), z(v.z), w(v.w) {}
 
-  explicit inline Vector(const T* a) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
+  explicit constexpr Vector(const T* a) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
 
-  explicit inline Vector(T s) : x(s), y(s), z(s), w(s) {}
+  explicit constexpr Vector(T s) : x(s), y(s), z(s), w(s) {}
 
-  inline Vector(T s1, T s2, T s3, T s4) : x(s1), y(s2), z(s3), w(s4) {}
+  constexpr Vector(T s1, T s2, T s3, T s4) : x(s1), y(s2), z(s3), w(s4) {}
 
-  inline Vector(const Vector<T, 3>& v123, T s4)
+  constexpr Vector(const Vector<T, 3>& v123, T s4)
       : x(v123.x), y(v123.y), z(v123.z), w(s4) {}
 
-  inline Vector(const Vector<T, 2>& v12, const Vector<T, 2>& v34)
+  constexpr Vector(const Vector<T, 2>& v12, const Vector<T, 2>& v34)
       : x(v12.x), y(v12.y), z(v34.x), w(v34.y) {}
 
   template <typename U>
-  explicit inline Vector(const Vector<U, 4>& v)
+  explicit constexpr Vector(const Vector<U, 4>& v)
       : x(static_cast<T>(v.x)),
         y(static_cast<T>(v.y)),
         z(static_cast<T>(v.z)),
         w(static_cast<T>(v.w)) {}
 
-  inline T& operator()(const int i) { return data_[i]; }
+  constexpr T& operator()(const int i) { return data_[i]; }
 
-  inline const T& operator()(const int i) const { return data_[i]; }
+  constexpr const T& operator()(const int i) const { return data_[i]; }
 
-  inline T& operator[](const int i) { return data_[i]; }
+  constexpr T& operator[](const int i) { return data_[i]; }
 
-  inline const T& operator[](const int i) const { return data_[i]; }
+  constexpr const T& operator[](const int i) const { return data_[i]; }
 
-  inline Vector<T, 3> xyz() { return Vector<T, 3>(x, y, z); }
+  constexpr Vector<T, 3> xyz() { return Vector<T, 3>(x, y, z); }
 
-  inline const Vector<T, 3> xyz() const { return Vector<T, 3>(x, y, z); }
+  constexpr const Vector<T, 3> xyz() const { return Vector<T, 3>(x, y, z); }
 
-  inline Vector<T, 2> xy() { return Vector<T, 2>(x, y); }
+  constexpr Vector<T, 2> xy() { return Vector<T, 2>(x, y); }
 
-  inline const Vector<T, 2> xy() const { return Vector<T, 2>(x, y); }
+  constexpr const Vector<T, 2> xy() const { return Vector<T, 2>(x, y); }
 
-  inline Vector<T, 2> zw() { return Vector<T, 2>(z, w); }
+  constexpr Vector<T, 2> zw() { return Vector<T, 2>(z, w); }
 
-  inline const Vector<T, 2> zw() const { return Vector<T, 2>(z, w); }
+  constexpr const Vector<T, 2> zw() const { return Vector<T, 2>(z, w); }
 
-  inline void Pack(VectorPacked<T, 4>* const vector) const {
+  constexpr void Pack(VectorPacked<T, 4>* const vector) const {
     vector->x = x;
     vector->y = y;
     vector->z = z;
     vector->w = w;
   }
 
-  inline T LengthSquared() const { return LengthSquaredHelper(*this); }
+  constexpr T LengthSquared() const { return LengthSquaredHelper(*this); }
 
   inline T Length() const { return LengthHelper(*this); }
 
@@ -99,39 +99,39 @@ class Vector<T, 4> {
     return ToTypeHelper<T, Dims, CompatibleT>(v);
   }
 
-  static inline T DotProduct(const Vector<T, 4>& v1, const Vector<T, 4>& v2) {
+  static constexpr T DotProduct(const Vector<T, 4>& v1,
+                                const Vector<T, 4>& v2) {
     return DotProductHelper(v1, v2);
   }
 
-  static inline Vector<T, 4> HadamardProduct(const Vector<T, 4>& v1,
-                                             const Vector<T, 4>& v2) {
+  static constexpr Vector<T, 4> HadamardProduct(const Vector<T, 4>& v1,
+                                                const Vector<T, 4>& v2) {
     return HadamardProductHelper(v1, v2);
   }
 
-  static inline Vector<T, 4> HadamardDivide(const Vector<T, 4>& v1,
-                                            const Vector<T, 4>& v2) {
+  static constexpr Vector<T, 4> HadamardDivide(const Vector<T, 4>& v1,
+                                               const Vector<T, 4>& v2) {
     return HadamardDivideHelper(v1, v2);
   }
 
-  static inline Vector<T, 4> Lerp(const Vector<T, 4>& v1,
-                                  const Vector<T, 4>& v2, const T percent) {
+  static constexpr Vector<T, 4> Lerp(const Vector<T, 4>& v1,
+                                     const Vector<T, 4>& v2, const T percent) {
     return LerpHelper(v1, v2, percent);
   }
 
-  static inline bool InRange(const Vector<T, 4>& val,
-                             const Vector<T, 4>& range_start,
-                             const Vector<T, 4>& range_end) {
+  static constexpr bool InRange(const Vector<T, 4>& val,
+                                const Vector<T, 4>& range_start,
+                                const Vector<T, 4>& range_end) {
     return InRangeHelper(val, range_start, range_end);
   }
 
-
-  static inline Vector<T, 4> Max(const Vector<T, 4>& v1,
-                                 const Vector<T, 4>& v2) {
+  static constexpr Vector<T, 4> Max(const Vector<T, 4>& v1,
+                                    const Vector<T, 4>& v2) {
     return MaxHelper(v1, v2);
   }
 
-  static inline Vector<T, 4> Min(const Vector<T, 4>& v1,
-                                 const Vector<T, 4>& v2) {
+  static constexpr Vector<T, 4> Min(const Vector<T, 4>& v1,
+                                    const Vector<T, 4>& v2) {
     return MinHelper(v1, v2);
   }
 
@@ -139,8 +139,8 @@ class Vector<T, 4> {
     return (v1 - v2).Length();
   }
 
-  static inline T DistanceSquared(const Vector<T, 4>& v1,
-                                  const Vector<T, 4>& v2) {
+  static constexpr T DistanceSquared(const Vector<T, 4>& v1,
+                                     const Vector<T, 4>& v2) {
     return (v1 - v2).LengthSquared();
   }
 
@@ -148,18 +148,18 @@ class Vector<T, 4> {
     return AngleHelper(v1, v2);
   }
 
-  static inline Vector<T, 4> Project(const Vector<T, 4>& v,
-                                     const Vector<T, 4>& onto) {
+  static constexpr Vector<T, 4> Project(const Vector<T, 4>& v,
+                                        const Vector<T, 4>& onto) {
     return ProjectHelper(v, onto);
   }
 
-  static inline Vector<T, 4> Reject(const Vector<T, 4>& v,
-                                    const Vector<T, 4>& from) {
+  static constexpr Vector<T, 4> Reject(const Vector<T, 4>& v,
+                                       const Vector<T, 4>& from) {
     return RejectHelper(v, from);
   }
 
-  static inline Vector<T, 4> Reflect(const Vector<T, 4>& incident,
-                                     const Vector<T, 4>& normal) {
+  static constexpr Vector<T, 4> Reflect(const Vector<T, 4>& incident,
+                                        const Vector<T, 4>& normal) {
     return ReflectHelper(incident, normal);
   }
 

--- a/include/mathfu/intersections.h
+++ b/include/mathfu/intersections.h
@@ -171,7 +171,7 @@ inline bool RayIntersectsPlane(const Ray<T, 3>& ray, const Plane<T>& plane,
 /// @param b Second AABB.
 /// @return true if the AABBs overlap (including touching boundaries).
 template <class T, int N>
-inline bool AABBIntersectsAABB(const AABB<T, N>& a, const AABB<T, N>& b) {
+constexpr bool AABBIntersectsAABB(const AABB<T, N>& a, const AABB<T, N>& b) {
   return a.Intersects(b);
 }
 
@@ -183,8 +183,8 @@ inline bool AABBIntersectsAABB(const AABB<T, N>& a, const AABB<T, N>& b) {
 /// @param b Second sphere.
 /// @return true if the spheres overlap.
 template <class T, int N>
-inline bool SphereIntersectsSphere(const Sphere<T, N>& a,
-                                   const Sphere<T, N>& b) {
+constexpr bool SphereIntersectsSphere(const Sphere<T, N>& a,
+                                      const Sphere<T, N>& b) {
   return a.Intersects(b);
 }
 
@@ -197,8 +197,8 @@ inline bool SphereIntersectsSphere(const Sphere<T, N>& a,
 /// @param aabb The AABB to test against.
 /// @return true if the sphere and AABB overlap.
 template <class T, int N>
-inline bool SphereIntersectsAABB(const Sphere<T, N>& sphere,
-                                 const AABB<T, N>& aabb) {
+constexpr bool SphereIntersectsAABB(const Sphere<T, N>& sphere,
+                                    const AABB<T, N>& aabb) {
   // Find the closest point on the AABB to the sphere center.
   Vector<T, N> closest;
   for (int i = 0; i < N; ++i) {
@@ -216,7 +216,7 @@ inline bool SphereIntersectsAABB(const Sphere<T, N>& sphere,
 /// @param aabb The AABB to test against.
 /// @return true if the point is inside or on the boundary of the AABB.
 template <class T, int N>
-inline bool PointInAABB(const Vector<T, N>& point, const AABB<T, N>& aabb) {
+constexpr bool PointInAABB(const Vector<T, N>& point, const AABB<T, N>& aabb) {
   return aabb.Contains(point);
 }
 
@@ -228,8 +228,8 @@ inline bool PointInAABB(const Vector<T, N>& point, const AABB<T, N>& aabb) {
 /// @param sphere The sphere to test against.
 /// @return true if the point is inside or on the boundary of the sphere.
 template <class T, int N>
-inline bool PointInSphere(const Vector<T, N>& point,
-                          const Sphere<T, N>& sphere) {
+constexpr bool PointInSphere(const Vector<T, N>& point,
+                             const Sphere<T, N>& sphere) {
   return sphere.Contains(point);
 }
 

--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -115,16 +115,16 @@ enum class Handedness {
 template <class T, int Rows, int Cols = Rows>
 class Matrix;
 template <class T, int Rows, int Cols>
-inline Matrix<T, Rows, Cols> IdentityHelper();
+constexpr Matrix<T, Rows, Cols> IdentityHelper();
 template <bool check_invertible, class T, int Rows, int Cols>
 inline bool InverseHelper(const Matrix<T, Rows, Cols>& m,
                           Matrix<T, Rows, Cols>* const inverse, T det_thresh);
 template <class T, int size1, int size2, int size3>
-inline void TimesHelper(const Matrix<T, size1, size2>& m1,
-                        const Matrix<T, size2, size3>& m2,
-                        Matrix<T, size1, size3>* out_m);
+constexpr void TimesHelper(const Matrix<T, size1, size2>& m1,
+                           const Matrix<T, size2, size3>& m2,
+                           Matrix<T, size1, size3>* out_m);
 template <class T, int Rows, int Cols>
-static inline Matrix<T, Rows, Cols> OuterProductHelper(
+static constexpr Matrix<T, Rows, Cols> OuterProductHelper(
     const Vector<T, Rows>& v1, const Vector<T, Cols>& v2);
 template <class T, Handedness H>
 inline Matrix<T, 4, 4> PerspectiveHelper(T fovy, T aspect, T znear, T zfar,
@@ -206,19 +206,19 @@ class Matrix {
   /// The elements of the Matrix are left uninitialized and have indeterminate
   /// values. This is intentional for performance: use Matrix(T), Identity(),
   /// or one of the factory methods if you need specific values.
-  inline Matrix() {}
+  constexpr Matrix() {}
 
   /// @brief Construct a Matrix from another Matrix copying each element.
   ////
   /// @param m Matrix that the data will be copied from.
-  inline Matrix(const Matrix<T, Rows, Cols>& m) {
+  constexpr Matrix(const Matrix<T, Rows, Cols>& m) {
     MATHFU_MAT_OPERATION(data_[i] = m.data_[i]);
   }
 
   /// @brief Construct a Matrix from a single float.
   ///
   /// @param s Scalar value used to initialize each element of the matrix.
-  explicit inline Matrix(T s) {
+  explicit constexpr Matrix(T s) {
     MATHFU_MAT_OPERATION((data_[i] = Vector<T, Rows>(s)));
   }
 
@@ -230,7 +230,7 @@ class Matrix {
   /// @param s10 Value of the second row, first column.
   /// @param s01 Value of the first row, second column.
   /// @param s11 Value of the second row and column.
-  inline Matrix(T s00, T s10, T s01, T s11) {
+  constexpr Matrix(T s00, T s10, T s01, T s11) {
     static_assert(Rows == 2 && Cols == 2, "Rows and Cols must be 2");
     data_[0] = Vector<T, Rows>(s00, s10);
     data_[1] = Vector<T, Rows>(s01, s11);
@@ -249,7 +249,8 @@ class Matrix {
   /// @param s02 Value of the first row, third column.
   /// @param s12 Value of the second row, third column.
   /// @param s22 Value of the third row and column.
-  inline Matrix(T s00, T s10, T s20, T s01, T s11, T s21, T s02, T s12, T s22) {
+  constexpr Matrix(T s00, T s10, T s20, T s01, T s11, T s21, T s02, T s12,
+                   T s22) {
     static_assert(Rows == 3 && Cols == 3, "Rows and Cols must be 3");
     data_[0] = Vector<T, Rows>(s00, s10, s20);
     data_[1] = Vector<T, Rows>(s01, s11, s21);
@@ -273,8 +274,8 @@ class Matrix {
   /// @param s12 Value of the second row, third column.
   /// @param s22 Value of the third row and column.
   /// @param s32 Value of the fourth row, third column.
-  inline Matrix(T s00, T s10, T s20, T s30, T s01, T s11, T s21, T s31, T s02,
-                T s12, T s22, T s32) {
+  constexpr Matrix(T s00, T s10, T s20, T s30, T s01, T s11, T s21, T s31,
+                   T s02, T s12, T s22, T s32) {
     static_assert(Rows == 4 && Cols == 3, "Rows must be 4 and Cols must be 3");
     data_[0] = Vector<T, Rows>(s00, s10, s20, s30);
     data_[1] = Vector<T, Rows>(s01, s11, s21, s31);
@@ -301,8 +302,8 @@ class Matrix {
   /// @param s13 Value of the second row, fourth column.
   /// @param s23 Value of the third row, fourth column.
   /// @param s33 Value of the fourth row and column.
-  inline Matrix(T s00, T s10, T s20, T s30, T s01, T s11, T s21, T s31, T s02,
-                T s12, T s22, T s32, T s03, T s13, T s23, T s33) {
+  constexpr Matrix(T s00, T s10, T s20, T s30, T s01, T s11, T s21, T s31,
+                   T s02, T s12, T s22, T s32, T s03, T s13, T s23, T s33) {
     static_assert(Rows == 4 && Cols == 4, "Rows and Cols must be 4");
     data_[0] = Vector<T, Rows>(s00, s10, s20, s30);
     data_[1] = Vector<T, Rows>(s01, s11, s21, s31);
@@ -318,8 +319,8 @@ class Matrix {
   /// @param column1 Vector used for the second column.
   /// @param column2 Vector used for the third column.
   /// @param column3 Vector used for the fourth column.
-  inline Matrix(const Vector<T, 4>& column0, const Vector<T, 4>& column1,
-                const Vector<T, 4>& column2, const Vector<T, 4>& column3) {
+  constexpr Matrix(const Vector<T, 4>& column0, const Vector<T, 4>& column1,
+                   const Vector<T, 4>& column2, const Vector<T, 4>& column3) {
     static_assert(Rows == 4 && Cols == 4, "Rows and Cols must be 4");
     data_[0] = column0;
     data_[1] = column1;
@@ -330,7 +331,7 @@ class Matrix {
   /// @brief Create a Matrix from the first row * column elements of an array.
   ///
   /// @param a Array of values that the matrix will be iniitlized to.
-  explicit inline Matrix(const T* const a) {
+  explicit constexpr Matrix(const T* const a) {
     MATHFU_MAT_OPERATION((data_[i] = Vector<T, Rows>(&a[i * Rows])));
   }
 
@@ -338,7 +339,7 @@ class Matrix {
   /// vectors.
   ///
   /// @param vectors Array of "Cols", "Rows" element packed vectors.
-  explicit inline Matrix(const VectorPacked<T, Rows>* const vectors) {
+  explicit constexpr Matrix(const VectorPacked<T, Rows>* const vectors) {
     MATHFU_MAT_OPERATION((data_[i] = Vector<T, Rows>(vectors[i])));
   }
 
@@ -347,7 +348,7 @@ class Matrix {
   /// @param row Index of the row to access.
   /// @param column Index of the column to access.
   /// @return Const reference to the element.
-  inline const T& operator()(const int row, const int column) const {
+  constexpr const T& operator()(const int row, const int column) const {
     return data_[column][row];
   }
 
@@ -356,7 +357,7 @@ class Matrix {
   /// @param row Index of the row to access.
   /// @param column Index of the column to access.
   /// @return Reference to the data that can be modified by the caller.
-  inline T& operator()(const int row, const int column) {
+  constexpr T& operator()(const int row, const int column) {
     return data_[column][row];
   }
 
@@ -365,21 +366,21 @@ class Matrix {
   /// @param i Index of the element to access in flattened memory.  Where
   /// the column accessed is i / Rows and the row is i % Rows.
   /// @return Reference to the data that can be modified by the caller.
-  inline const T& operator()(const int i) const { return operator[](i); }
+  constexpr const T& operator()(const int i) const { return operator[](i); }
 
   /// @brief Access an element of the Matrix.
   ///
   /// @param i Index of the element to access in flattened memory.  Where
   /// the column accessed is i / Rows and the row is i % Rows.
   /// @return Reference to the data that can be modified by the caller.
-  inline T& operator()(const int i) { return operator[](i); }
+  constexpr T& operator()(const int i) { return operator[](i); }
 
   /// @brief Access an element of the Matrix.
   ///
   /// @param i Index of the element to access in flattened memory.  Where
   /// the column accessed is i / Rows and the row is i % Rows.
   /// @return Const reference to the data.
-  inline const T& operator[](const int i) const {
+  constexpr const T& operator[](const int i) const {
     const int col = i / Rows;
     const int row = i % Rows;
     return data_[col][row];
@@ -390,7 +391,7 @@ class Matrix {
   /// @param i Index of the element to access in flattened memory.  Where
   /// the column accessed is i / Rows and the row is i % Rows.
   /// @return Reference to the data that can be modified by the caller.
-  inline T& operator[](const int i) {
+  constexpr T& operator[](const int i) {
     const int col = i / Rows;
     const int row = i % Rows;
     return data_[col][row];
@@ -400,7 +401,7 @@ class Matrix {
   /// one vector per matrix column.
   ///
   /// @param vector Array of "Cols" entries to write to.
-  inline void Pack(VectorPacked<T, Rows>* const vector) const {
+  constexpr void Pack(VectorPacked<T, Rows>* const vector) const {
     MATHFU_MAT_OPERATION(GetColumn(i).Pack(&vector[i]));
   }
 
@@ -408,13 +409,13 @@ class Matrix {
   ///
   /// @param i Index of the column to access.
   /// @return Reference to the data that can be modified by the caller.
-  inline Vector<T, Rows>& GetColumn(const int i) { return data_[i]; }
+  constexpr Vector<T, Rows>& GetColumn(const int i) { return data_[i]; }
 
   /// @brief Access a column vector of the Matrix.
   ///
   /// @param i Index of the column to access.
   /// @return Const reference to the data.
-  inline const Vector<T, Rows>& GetColumn(const int i) const {
+  constexpr const Vector<T, Rows>& GetColumn(const int i) const {
     return data_[i];
   }
 
@@ -425,7 +426,7 @@ class Matrix {
   ///
   /// @param i Index of the row to access.
   /// @return Vector containing the row elements.
-  inline Vector<T, Cols> GetRow(const int i) const {
+  constexpr Vector<T, Cols> GetRow(const int i) const {
     Vector<T, Cols> result;
     for (int j = 0; j < Cols; j++) {
       result[j] = data_[j][i];
@@ -436,7 +437,7 @@ class Matrix {
   /// @brief Negate this Matrix.
   ///
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator-() const {
+  constexpr Matrix<T, Rows, Cols> operator-() const {
     MATHFU_MAT_OPERATOR(-data_[i]);
   }
 
@@ -444,7 +445,8 @@ class Matrix {
   ///
   /// @param m Matrix to add to this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator+(const Matrix<T, Rows, Cols>& m) const {
+  constexpr Matrix<T, Rows, Cols> operator+(
+      const Matrix<T, Rows, Cols>& m) const {
     MATHFU_MAT_OPERATOR(data_[i] + m.data_[i]);
   }
 
@@ -452,7 +454,8 @@ class Matrix {
   ///
   /// @param m Matrix to subtract from this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator-(const Matrix<T, Rows, Cols>& m) const {
+  constexpr Matrix<T, Rows, Cols> operator-(
+      const Matrix<T, Rows, Cols>& m) const {
     MATHFU_MAT_OPERATOR(data_[i] - m.data_[i]);
   }
 
@@ -460,7 +463,7 @@ class Matrix {
   ///
   /// @param s Scalar to add to this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator+(T s) const {
+  constexpr Matrix<T, Rows, Cols> operator+(T s) const {
     MATHFU_MAT_OPERATOR(data_[i] + s);
   }
 
@@ -468,7 +471,7 @@ class Matrix {
   ///
   /// @param s Scalar to subtract from this matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator-(T s) const {
+  constexpr Matrix<T, Rows, Cols> operator-(T s) const {
     MATHFU_MAT_OPERATOR(data_[i] - s);
   }
 
@@ -476,7 +479,7 @@ class Matrix {
   ///
   /// @param s Scalar to multiply with this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator*(T s) const {
+  constexpr Matrix<T, Rows, Cols> operator*(T s) const {
     MATHFU_MAT_OPERATOR(data_[i] * s);
   }
 
@@ -484,7 +487,7 @@ class Matrix {
   ///
   /// @param s Scalar to divide this Matrix by. Must be non-zero.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator/(T s) const {
+  constexpr Matrix<T, Rows, Cols> operator/(T s) const {
     return (*this) * (T(1) / s);
   }
 
@@ -496,7 +499,8 @@ class Matrix {
   ///
   /// @param m Matrix to multiply with this Matrix.
   /// @return Matrix containing the result.
-  inline Matrix<T, Rows, Cols> operator*(const Matrix<T, Rows, Cols>& m) const {
+  constexpr Matrix<T, Rows, Cols> operator*(
+      const Matrix<T, Rows, Cols>& m) const {
     static_assert(Rows == Cols,
                   "operator* requires square matrices; use Multiply() for "
                   "non-square matrix multiplication");
@@ -509,7 +513,7 @@ class Matrix {
   ///
   /// @param m Matrix to add to this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator+=(const Matrix<T, Rows, Cols>& m) {
+  constexpr Matrix<T, Rows, Cols>& operator+=(const Matrix<T, Rows, Cols>& m) {
     MATHFU_MAT_SELF_OPERATOR(data_[i] += m.data_[i]);
   }
 
@@ -517,7 +521,7 @@ class Matrix {
   ///
   /// @param m Matrix to subtract from this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator-=(const Matrix<T, Rows, Cols>& m) {
+  constexpr Matrix<T, Rows, Cols>& operator-=(const Matrix<T, Rows, Cols>& m) {
     MATHFU_MAT_SELF_OPERATOR(data_[i] -= m.data_[i]);
   }
 
@@ -525,7 +529,7 @@ class Matrix {
   ///
   /// @param s Scalar to add to each element of this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator+=(T s) {
+  constexpr Matrix<T, Rows, Cols>& operator+=(T s) {
     MATHFU_MAT_SELF_OPERATOR(data_[i] += s);
   }
 
@@ -533,7 +537,7 @@ class Matrix {
   ///
   /// @param s Scalar to subtract from each element of this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator-=(T s) {
+  constexpr Matrix<T, Rows, Cols>& operator-=(T s) {
     MATHFU_MAT_SELF_OPERATOR(data_[i] -= s);
   }
 
@@ -541,7 +545,7 @@ class Matrix {
   ///
   /// @param s Scalar to multiply with each element of this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator*=(T s) {
+  constexpr Matrix<T, Rows, Cols>& operator*=(T s) {
     MATHFU_MAT_SELF_OPERATOR(data_[i] *= s);
   }
 
@@ -549,7 +553,7 @@ class Matrix {
   ///
   /// @param s Scalar to divide this Matrix by. Must be non-zero.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator/=(T s) {
+  constexpr Matrix<T, Rows, Cols>& operator/=(T s) {
     return (*this) *= (T(1) / s);
   }
 
@@ -561,7 +565,7 @@ class Matrix {
   ///
   /// @param m Matrix to multiply with this Matrix.
   /// @return Reference to this class.
-  inline Matrix<T, Rows, Cols>& operator*=(const Matrix<T, Rows, Cols>& m) {
+  constexpr Matrix<T, Rows, Cols>& operator*=(const Matrix<T, Rows, Cols>& m) {
     static_assert(Rows == Cols,
                   "operator*= requires square matrices; use Multiply() for "
                   "non-square matrix multiplication");
@@ -611,7 +615,7 @@ class Matrix {
   /// @brief Calculate the transpose of this Matrix.
   ///
   /// @return The transpose of the specified Matrix.
-  inline Matrix<T, Cols, Rows> Transpose() const {
+  constexpr Matrix<T, Cols, Rows> Transpose() const {
     Matrix<T, Cols, Rows> transpose;
     MATHFU_UNROLLED_LOOP(
         i, Cols,
@@ -625,7 +629,7 @@ class Matrix {
   ///
   /// @note 2-dimensional affine transforms are represented by 3x3 matrices.
   /// @return Vector with the first two components of column 2 of this Matrix.
-  inline Vector<T, 2> TranslationVector2D() const {
+  constexpr Vector<T, 2> TranslationVector2D() const {
     static_assert(Rows == 3 && Cols == 3, "Rows and Cols must be 3");
     return Vector<T, 2>(data_[2][0], data_[2][1]);
   }
@@ -635,7 +639,7 @@ class Matrix {
   ///
   /// @note 3-dimensional affine transforms are represented by 4x4 matrices.
   /// @return Vector with the first three components of column 3.
-  inline Vector<T, 3> TranslationVector3D() const {
+  constexpr Vector<T, 3> TranslationVector3D() const {
     static_assert(Rows == 4 && Cols == 4, "Rows and Cols must be 4");
     return Vector<T, 3>(data_[3][0], data_[3][1], data_[3][2]);
   }
@@ -690,8 +694,8 @@ class Matrix {
   /// @brief Calculate the outer product of two Vectors.
   ///
   /// @return Matrix containing the result.
-  static inline Matrix<T, Rows, Cols> OuterProduct(const Vector<T, Rows>& v1,
-                                                   const Vector<T, Cols>& v2) {
+  static constexpr Matrix<T, Rows, Cols> OuterProduct(
+      const Vector<T, Rows>& v1, const Vector<T, Cols>& v2) {
     return OuterProductHelper(v1, v2);
   }
 
@@ -700,7 +704,7 @@ class Matrix {
   /// @param m1 First Matrix.
   /// @param m2 Second Matrix.
   /// @return Matrix containing the result.
-  static inline Matrix<T, Rows, Cols> HadamardProduct(
+  static constexpr Matrix<T, Rows, Cols> HadamardProduct(
       const Matrix<T, Rows, Cols>& m1, const Matrix<T, Rows, Cols>& m2) {
     MATHFU_MAT_OPERATOR(HadamardProductHelper(m1.data_[i], m2.data_[i]));
   }
@@ -708,7 +712,7 @@ class Matrix {
   /// @brief Calculate the identity Matrix.
   ///
   /// @return Matrix containing the result.
-  static inline Matrix<T, Rows, Cols> Identity() {
+  static constexpr Matrix<T, Rows, Cols> Identity() {
     return IdentityHelper<T, Rows, Cols>();
   }
 
@@ -718,7 +722,7 @@ class Matrix {
   ///
   /// @param v Vector of size 2.
   /// @return Matrix containing the result.
-  static inline Matrix<T, 3> FromTranslationVector(const Vector<T, 2>& v) {
+  static constexpr Matrix<T, 3> FromTranslationVector(const Vector<T, 2>& v) {
     return Matrix<T, 3>(1, 0, 0, 0, 1, 0, v[0], v[1], 1);
   }
 
@@ -728,7 +732,7 @@ class Matrix {
   ///
   /// @param v The vector of size 3.
   /// @return Matrix containing the result.
-  static inline Matrix<T, 4> FromTranslationVector(const Vector<T, 3>& v) {
+  static constexpr Matrix<T, 4> FromTranslationVector(const Vector<T, 3>& v) {
     return Matrix<T, 4>(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, v[0], v[1], v[2],
                         1);
   }
@@ -740,7 +744,8 @@ class Matrix {
   ///
   /// @param v Vector containing components for scaling.
   /// @return Matrix with v along the diagonal, and 1 in the bottom right.
-  static inline Matrix<T, Rows> FromScaleVector(const Vector<T, Rows - 1>& v) {
+  static constexpr Matrix<T, Rows> FromScaleVector(
+      const Vector<T, Rows - 1>& v) {
     // TODO OPT: Use a helper function in a similar way to Identity to
     // construct the matrix for the specialized cases 2, 3, 4, and only run
     // this method in the general case. This will also allow you to use the
@@ -756,7 +761,7 @@ class Matrix {
   ///
   /// @param m 3x3 rotation Matrix.
   /// @return Matrix containing the result.
-  static inline Matrix<T, 4> FromRotationMatrix(const Matrix<T, 3>& m) {
+  static constexpr Matrix<T, 4> FromRotationMatrix(const Matrix<T, 3>& m) {
     return Matrix<T, 4>(m[0], m[1], m[2], 0, m[3], m[4], m[5], 0, m[6], m[7],
                         m[8], 0, 0, 0, 0, 1);
   }
@@ -768,7 +773,7 @@ class Matrix {
   ///
   /// @param m 4x4 Matrix.
   /// @return rotation Matrix containing the result.
-  static inline Matrix<T, 3> ToRotationMatrix(const Matrix<T, 4>& m) {
+  static constexpr Matrix<T, 3> ToRotationMatrix(const Matrix<T, 4>& m) {
     return Matrix<T, 3>(m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]);
   }
 
@@ -776,7 +781,7 @@ class Matrix {
   ///
   /// @param affine An AffineTransform reference to be used to construct
   /// a Matrix<float, 4> by adding in the 'w' row of [0, 0, 0, 1].
-  static inline Matrix<T, 4> FromAffineTransform(
+  static constexpr Matrix<T, 4> FromAffineTransform(
       const Matrix<T, 4, 3>& affine) {
     return Matrix<T, 4>(affine[0], affine[4], affine[8], static_cast<T>(0),
                         affine[1], affine[5], affine[9], static_cast<T>(0),
@@ -791,7 +796,7 @@ class Matrix {
   ///
   /// @return Returns an AffineTransform that contains the essential
   /// transformation data from the Matrix<float, 4>.
-  static inline Matrix<T, 4, 3> ToAffineTransform(const Matrix<T, 4>& m) {
+  static constexpr Matrix<T, 4, 3> ToAffineTransform(const Matrix<T, 4>& m) {
     return Matrix<T, 4, 3>(m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13],
                            m[2], m[6], m[10], m[14]);
   }
@@ -801,7 +806,7 @@ class Matrix {
   ///
   /// @param v 2D normalized directional Vector.
   /// @return Matrix containing the result.
-  static inline Matrix<T, 3> RotationX(const Vector<T, 2>& v) {
+  static constexpr Matrix<T, 3> RotationX(const Vector<T, 2>& v) {
     return Matrix<T, 3>(1, 0, 0, 0, v.x, v.y, 0, -v.y, v.x);
   }
 
@@ -810,7 +815,7 @@ class Matrix {
   ///
   /// @param v 2D normalized directional Vector.
   /// @return Matrix containing the result.
-  static inline Matrix<T, 3> RotationY(const Vector<T, 2>& v) {
+  static constexpr Matrix<T, 3> RotationY(const Vector<T, 2>& v) {
     return Matrix<T, 3>(v.x, 0, -v.y, 0, 1, 0, v.y, 0, v.x);
   }
 
@@ -819,7 +824,7 @@ class Matrix {
   ///
   /// @param v 2D normalized directional Vector.
   /// @return Matrix containing the result.
-  static inline Matrix<T, 3> RotationZ(const Vector<T, 2>& v) {
+  static constexpr Matrix<T, 3> RotationZ(const Vector<T, 2>& v) {
     return Matrix<T, 3>(v.x, v.y, 0, -v.y, v.x, 0, 0, 0, 1);
   }
 
@@ -946,8 +951,8 @@ class Matrix {
   /// @param v Vector to multiply.
   /// @param m Matrix to multiply.
   /// @return Matrix containing the result.
-  friend inline Vector<T, Cols> operator*(const Vector<T, Rows>& v,
-                                          const Matrix<T, Rows, Cols>& m) {
+  friend constexpr Vector<T, Cols> operator*(const Vector<T, Rows>& v,
+                                             const Matrix<T, Rows, Cols>& m) {
     const int Dims = Cols;
     MATHFU_VECTOR_OPERATOR((Vector<T, Rows>::DotProduct(m.data_[i], v)));
   }
@@ -963,12 +968,12 @@ class Matrix {
   /// @brief Access the underlying column data array.
   ///
   /// @return Pointer to the first column vector.
-  inline const Vector<T, Rows>* data() const { return data_; }
+  constexpr const Vector<T, Rows>* data() const { return data_; }
 
   /// @brief Access the underlying column data array.
   ///
   /// @return Pointer to the first column vector.
-  inline Vector<T, Rows>* data() { return data_; }
+  constexpr Vector<T, Rows>* data() { return data_; }
 
   MATHFU_DEFINE_CLASS_SIMD_AWARE_NEW_DELETE
 
@@ -984,8 +989,8 @@ class Matrix {
 template <int index>
 struct MathfuMatrixUnroller {
   template <class T, int Rows, int Cols>
-  inline static bool NotEqual(const Matrix<T, Rows, Cols>& lhs,
-                              const Matrix<T, Rows, Cols>& rhs) {
+  constexpr static bool NotEqual(const Matrix<T, Rows, Cols>& lhs,
+                                 const Matrix<T, Rows, Cols>& rhs) {
     return (lhs[index] != rhs[index])
            || MathfuMatrixUnroller<index - 1>::NotEqual(lhs, rhs);
   }
@@ -993,8 +998,8 @@ struct MathfuMatrixUnroller {
 template <>
 struct MathfuMatrixUnroller<0> {
   template <class T, int Rows, int Cols>
-  inline static bool NotEqual(const Matrix<T, Rows, Cols>& lhs,
-                              const Matrix<T, Rows, Cols>& rhs) {
+  constexpr static bool NotEqual(const Matrix<T, Rows, Cols>& lhs,
+                                 const Matrix<T, Rows, Cols>& rhs) {
     return lhs[0] != rhs[0];
   }
 };
@@ -1006,8 +1011,8 @@ struct MathfuMatrixUnroller<0> {
 ///
 /// @return true if the elements of 2 matrices differ, false otherwise.
 template <class T, int Rows, int Cols>
-inline bool operator!=(const Matrix<T, Rows, Cols>& lhs,
-                       const Matrix<T, Rows, Cols>& rhs) {
+constexpr bool operator!=(const Matrix<T, Rows, Cols>& lhs,
+                          const Matrix<T, Rows, Cols>& rhs) {
   return MathfuMatrixUnroller<Rows * Cols - 1>::NotEqual(lhs, rhs);
 }
 
@@ -1015,8 +1020,8 @@ inline bool operator!=(const Matrix<T, Rows, Cols>& lhs,
 ///
 /// @return true if the 2 matrices contains the same values, false otherwise.
 template <class T, int Rows, int Cols>
-inline bool operator==(const Matrix<T, Rows, Cols>& lhs,
-                       const Matrix<T, Rows, Cols>& rhs) {
+constexpr bool operator==(const Matrix<T, Rows, Cols>& lhs,
+                          const Matrix<T, Rows, Cols>& rhs) {
   return !(lhs != rhs);
 }
 
@@ -1031,7 +1036,7 @@ inline bool operator==(const Matrix<T, Rows, Cols>& lhs,
 ///
 /// @related mathfu::Matrix
 template <class T, int Rows, int Cols>
-inline Matrix<T, Rows, Cols> operator*(T s, const Matrix<T, Cols, Rows>& m) {
+constexpr Matrix<T, Rows, Cols> operator*(T s, const Matrix<T, Cols, Rows>& m) {
   return m * s;
 }
 
@@ -1047,8 +1052,8 @@ inline Matrix<T, Rows, Cols> operator*(T s, const Matrix<T, Cols, Rows>& m) {
 ///
 /// @related mathfu::Matrix
 template <class T, int Rows, int Cols>
-inline Vector<T, Rows> operator*(const Matrix<T, Rows, Cols>& m,
-                                 const Vector<T, Cols>& v) {
+constexpr Vector<T, Rows> operator*(const Matrix<T, Rows, Cols>& m,
+                                    const Vector<T, Cols>& v) {
   Vector<T, Rows> result(static_cast<T>(0));
   int offset = 0;
   for (int column = 0; column < Cols; column++) {
@@ -1062,14 +1067,16 @@ inline Vector<T, Rows> operator*(const Matrix<T, Rows, Cols>& m,
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline Vector<T, 2> operator*(const Matrix<T, 2, 2>& m, const Vector<T, 2>& v) {
+constexpr Vector<T, 2> operator*(const Matrix<T, 2, 2>& m,
+                                 const Vector<T, 2>& v) {
   return Vector<T, 2>(m[0] * v[0] + m[2] * v[1], m[1] * v[0] + m[3] * v[1]);
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline Vector<T, 3> operator*(const Matrix<T, 3, 3>& m, const Vector<T, 3>& v) {
+constexpr Vector<T, 3> operator*(const Matrix<T, 3, 3>& m,
+                                 const Vector<T, 3>& v) {
   return Vector<T, 3>(MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 0, 3),
                       MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 1, 3),
                       MATHFU_MATRIX_3X3_DOT(&m.GetColumn(0).data_[0], v, 2, 3));
@@ -1092,7 +1099,8 @@ inline Vector<float, 3> operator*(const Matrix<float, 3, 3>& m,
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline Vector<T, 4> operator*(const Matrix<T, 4, 4>& m, const Vector<T, 4>& v) {
+constexpr Vector<T, 4> operator*(const Matrix<T, 4, 4>& m,
+                                 const Vector<T, 4>& v) {
   return Vector<T, 4>(MATHFU_MATRIX_4X4_DOT(&m.GetColumn(0).data_[0], v, 0),
                       MATHFU_MATRIX_4X4_DOT(&m.GetColumn(0).data_[0], v, 1),
                       MATHFU_MATRIX_4X4_DOT(&m.GetColumn(0).data_[0], v, 2),
@@ -1124,7 +1132,8 @@ inline Vector<T, 4> operator*(const Matrix<T, 4, 4>& m, const Vector<T, 4>& v) {
 ///
 /// @related mathfu::Matrix
 template <class T>
-inline Vector<T, 3> operator*(const Matrix<T, 4, 4>& m, const Vector<T, 3>& v) {
+constexpr Vector<T, 3> operator*(const Matrix<T, 4, 4>& m,
+                                 const Vector<T, 3>& v) {
   Vector<T, 4> v4(v[0], v[1], v[2], T(1));
   v4 = m * v4;
   assert(v4[3] != 0);
@@ -1149,8 +1158,8 @@ inline Vector<T, 3> operator*(const Matrix<T, 4, 4>& m, const Vector<T, 3>& v) {
 ///
 /// @related mathfu::Matrix
 template <class T>
-inline Vector<T, 3> TransformPoint3D(const Matrix<T, 4, 4>& m,
-                                     const Vector<T, 3>& v) {
+constexpr Vector<T, 3> TransformPoint3D(const Matrix<T, 4, 4>& m,
+                                        const Vector<T, 3>& v) {
   Vector<T, 4> v4(v[0], v[1], v[2], 1);
   v4 = m * v4;
   return Vector<T, 3>(v4[0], v4[1], v4[2]);
@@ -1172,9 +1181,9 @@ inline Vector<T, 3> TransformPoint3D(const Matrix<T, 4, 4>& m,
 /// @tparam size2 Number of Cols in the returned Matrix and Rows in m2.
 /// @tparam size3 Number of Cols in m3.
 template <class T, int size1, int size2, int size3>
-inline void TimesHelper(const Matrix<T, size1, size2>& m1,
-                        const Matrix<T, size2, size3>& m2,
-                        Matrix<T, size1, size3>* out_m) {
+constexpr void TimesHelper(const Matrix<T, size1, size2>& m1,
+                           const Matrix<T, size2, size3>& m2,
+                           Matrix<T, size1, size3>* out_m) {
   for (int i = 0; i < size1; i++) {
     for (int j = 0; j < size3; j++) {
       Vector<T, size2> row;
@@ -1189,8 +1198,8 @@ inline void TimesHelper(const Matrix<T, size1, size2>& m1,
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline void TimesHelper(const Matrix<T, 2, 2>& m1, const Matrix<T, 2, 2>& m2,
-                        Matrix<T, 2, 2>* out_m) {
+constexpr void TimesHelper(const Matrix<T, 2, 2>& m1, const Matrix<T, 2, 2>& m2,
+                           Matrix<T, 2, 2>* out_m) {
   Matrix<T, 2, 2>& out = *out_m;
   out[0] = m1[0] * m2[0] + m1[2] * m2[1];
   out[1] = m1[1] * m2[0] + m1[3] * m2[1];
@@ -1201,8 +1210,8 @@ inline void TimesHelper(const Matrix<T, 2, 2>& m1, const Matrix<T, 2, 2>& m2,
 
 /// @cond MATHFU_INTERNAL
 template <typename T>
-inline void TimesHelper(const Matrix<T, 3, 3>& m1, const Matrix<T, 3, 3>& m2,
-                        Matrix<T, 3, 3>* out_m) {
+constexpr void TimesHelper(const Matrix<T, 3, 3>& m1, const Matrix<T, 3, 3>& m2,
+                           Matrix<T, 3, 3>* out_m) {
   Matrix<T, 3, 3>& out = *out_m;
   {
     Vector<T, 3> row(m1[0], m1[3], m1[6]);
@@ -1227,8 +1236,8 @@ inline void TimesHelper(const Matrix<T, 3, 3>& m1, const Matrix<T, 3, 3>& m2,
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline void TimesHelper(const Matrix<T, 4, 4>& m1, const Matrix<T, 4, 4>& m2,
-                        Matrix<T, 4, 4>* out_m) {
+constexpr void TimesHelper(const Matrix<T, 4, 4>& m1, const Matrix<T, 4, 4>& m2,
+                           Matrix<T, 4, 4>* out_m) {
   Matrix<T, 4, 4>& out = *out_m;
   {
     Vector<T, 4> row(m1[0], m1[4], m1[8], m1[12]);
@@ -1279,8 +1288,8 @@ inline void TimesHelper(const Matrix<T, 4, 4>& m1, const Matrix<T, 4, 4>& m2,
 ///
 /// @related mathfu::Matrix
 template <class T, int R1, int C1, int C2>
-inline Matrix<T, R1, C2> Multiply(const Matrix<T, R1, C1>& m1,
-                                  const Matrix<T, C1, C2>& m2) {
+constexpr Matrix<T, R1, C2> Multiply(const Matrix<T, R1, C1>& m1,
+                                     const Matrix<T, C1, C2>& m2) {
   Matrix<T, R1, C2> result;
   for (int c = 0; c < C2; ++c) {
     for (int r = 0; r < R1; ++r) {
@@ -1305,7 +1314,7 @@ inline Matrix<T, R1, C2> Multiply(const Matrix<T, R1, C1>& m1,
 /// @tparam Rows Number of Rows in the returned Matrix.
 /// @tparam Cols Number of Cols in the returned Matrix.
 template <class T, int Rows, int Cols>
-inline Matrix<T, Rows, Cols> IdentityHelper() {
+constexpr Matrix<T, Rows, Cols> IdentityHelper() {
   Matrix<T, Rows, Cols> return_matrix(T(0));
   int min_d = Rows < Cols ? Rows : Cols;
   for (int i = 0; i < min_d; ++i) return_matrix(i, i) = T(1);
@@ -1315,21 +1324,21 @@ inline Matrix<T, Rows, Cols> IdentityHelper() {
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline Matrix<T, 2, 2> IdentityHelper() {
+constexpr Matrix<T, 2, 2> IdentityHelper() {
   return Matrix<T, 2, 2>(1, 0, 0, 1);
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline Matrix<T, 3, 3> IdentityHelper() {
+constexpr Matrix<T, 3, 3> IdentityHelper() {
   return Matrix<T, 3, 3>(1, 0, 0, 0, 1, 0, 0, 0, 1);
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-inline Matrix<T, 4, 4> IdentityHelper() {
+constexpr Matrix<T, 4, 4> IdentityHelper() {
   return Matrix<T, 4, 4>(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
 }
 /// @endcond
@@ -1340,7 +1349,7 @@ inline Matrix<T, 4, 4> IdentityHelper() {
 /// @note There are template specialization for 2x2, 3x3, and 4x4 matrices to
 /// increase performance.
 template <class T, int Rows, int Cols>
-static inline Matrix<T, Rows, Cols> OuterProductHelper(
+static constexpr Matrix<T, Rows, Cols> OuterProductHelper(
     const Vector<T, Rows>& v1, const Vector<T, Cols>& v2) {
   Matrix<T, Rows, Cols> result(static_cast<T>(0));
   int offset = 0;
@@ -1356,8 +1365,8 @@ static inline Matrix<T, Rows, Cols> OuterProductHelper(
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-static inline Matrix<T, 2, 2> OuterProductHelper(const Vector<T, 2>& v1,
-                                                 const Vector<T, 2>& v2) {
+static constexpr Matrix<T, 2, 2> OuterProductHelper(const Vector<T, 2>& v1,
+                                                    const Vector<T, 2>& v2) {
   return Matrix<T, 2, 2>(v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1],
                          v1[1] * v2[1]);
 }
@@ -1365,8 +1374,8 @@ static inline Matrix<T, 2, 2> OuterProductHelper(const Vector<T, 2>& v1,
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-static inline Matrix<T, 3, 3> OuterProductHelper(const Vector<T, 3>& v1,
-                                                 const Vector<T, 3>& v2) {
+static constexpr Matrix<T, 3, 3> OuterProductHelper(const Vector<T, 3>& v1,
+                                                    const Vector<T, 3>& v2) {
   return Matrix<T, 3, 3>(v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0],
                          v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1],
                          v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2]);
@@ -1375,8 +1384,8 @@ static inline Matrix<T, 3, 3> OuterProductHelper(const Vector<T, 3>& v1,
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-static inline Matrix<T, 4, 4> OuterProductHelper(const Vector<T, 4>& v1,
-                                                 const Vector<T, 4>& v2) {
+static constexpr Matrix<T, 4, 4> OuterProductHelper(const Vector<T, 4>& v1,
+                                                    const Vector<T, 4>& v2) {
   return Matrix<T, 4, 4>(
       v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1],
       v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1], v1[0] * v2[2], v1[1] * v2[2],
@@ -1663,9 +1672,9 @@ static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
 /// @cond MATHFU_INTERNAL
 /// Create a 3-dimensional transform matrix.
 template <class T>
-static inline Matrix<T, 4, 4> TransformHelper(const Vector<T, 3>& position,
-                                              const Matrix<T, 3, 3>& rotation,
-                                              const Vector<T, 3>& scale) {
+static constexpr Matrix<T, 4, 4> TransformHelper(
+    const Vector<T, 3>& position, const Matrix<T, 3, 3>& rotation,
+    const Vector<T, 3>& scale) {
   Vector<T, 4> c0(rotation(0, 0), rotation(1, 0), rotation(2, 0), 0);
   Vector<T, 4> c1(rotation(0, 1), rotation(1, 1), rotation(2, 1), 0);
   Vector<T, 4> c2(rotation(0, 2), rotation(1, 2), rotation(2, 2), 0);

--- a/include/mathfu/plane.h
+++ b/include/mathfu/plane.h
@@ -45,22 +45,23 @@ struct Plane {
   ///
   /// @param normal The normal vector of the plane.
   /// @param distance The signed distance from the origin.
-  inline Plane(const Vector<T, 3>& normal, T distance)
+  constexpr Plane(const Vector<T, 3>& normal, T distance)
       : normal(normal), distance(distance) {}
 
   /// @brief Create a plane from a Vector4 (xyz = normal, w = distance).
   ///
   /// @param v Vector4 where xyz components are the normal and w is the
   ///          signed distance.
-  explicit Plane(const Vector<T, 4>& v) : normal(v.xyz()), distance(v[3]) {}
+  explicit constexpr Plane(const Vector<T, 4>& v)
+      : normal(v.xyz()), distance(v[3]) {}
 
   /// @brief Create a plane through a point with a given normal.
   ///
   /// @param point A point on the plane.
   /// @param normal The normal vector of the plane.
   /// @return A Plane passing through the given point with the given normal.
-  static inline Plane<T> FromPointNormal(const Vector<T, 3>& point,
-                                         const Vector<T, 3>& normal) {
+  static constexpr Plane<T> FromPointNormal(const Vector<T, 3>& point,
+                                            const Vector<T, 3>& normal) {
     return Plane<T>(normal, -Vector<T, 3>::DotProduct(normal, point));
   }
 
@@ -89,7 +90,7 @@ struct Plane {
   ///
   /// @param point The point to compute the distance for.
   /// @return The signed distance from the point to the plane.
-  inline T SignedDistance(const Vector<T, 3>& point) const {
+  constexpr T SignedDistance(const Vector<T, 3>& point) const {
     return Vector<T, 3>::DotProduct(normal, point) + distance;
   }
 
@@ -97,7 +98,7 @@ struct Plane {
   ///
   /// @param point The point to project.
   /// @return The closest point on the plane to the given point.
-  inline Vector<T, 3> ProjectPoint(const Vector<T, 3>& point) const {
+  constexpr Vector<T, 3> ProjectPoint(const Vector<T, 3>& point) const {
     return point - normal * SignedDistance(point);
   }
 
@@ -107,7 +108,7 @@ struct Plane {
   /// opposite facing direction.
   ///
   /// @return A new Plane with negated normal and distance.
-  inline Plane<T> Flipped() const { return Plane<T>(-normal, -distance); }
+  constexpr Plane<T> Flipped() const { return Plane<T>(-normal, -distance); }
 };
 /// @}
 
@@ -116,7 +117,7 @@ struct Plane {
 /// @param p1 Plane to be tested.
 /// @param p2 Other plane to be tested.
 template <class T>
-bool operator==(const Plane<T>& p1, const Plane<T>& p2) {
+constexpr bool operator==(const Plane<T>& p1, const Plane<T>& p2) {
   return (p1.normal == p2.normal && p1.distance == p2.distance);
 }
 
@@ -125,7 +126,7 @@ bool operator==(const Plane<T>& p1, const Plane<T>& p2) {
 /// @param p1 Plane to be tested.
 /// @param p2 Other plane to be tested.
 template <class T>
-bool operator!=(const Plane<T>& p1, const Plane<T>& p2) {
+constexpr bool operator!=(const Plane<T>& p1, const Plane<T>& p2) {
   return !(p1 == p2);
 }
 

--- a/include/mathfu/quaternion.h
+++ b/include/mathfu/quaternion.h
@@ -48,11 +48,11 @@ class Quaternion {
   /// and have indeterminate values. This is intentional for performance: use
   /// Quaternion(T, T, T, T) or Quaternion::identity if you need specific
   /// values.
-  inline Quaternion() {}
+  constexpr Quaternion() {}
 
   /// @brief Construct a Quaternion from a copy.
   /// @param q Quaternion to copy.
-  inline Quaternion(const Quaternion<T>& q) : data_(q.data_) {}
+  constexpr Quaternion(const Quaternion<T>& q) : data_(q.data_) {}
 
   /// @brief Construct a Quaternion using scalar values to initialize each
   /// element.
@@ -61,36 +61,36 @@ class Quaternion {
   /// @param qs1 First element of the Vector component.
   /// @param qs2 Second element of the Vector component.
   /// @param qs3 Third element of the Vector component.
-  inline Quaternion(T s1, T qs1, T qs2, T qs3) : data_(s1, qs1, qs2, qs3) {}
+  constexpr Quaternion(T s1, T qs1, T qs2, T qs3) : data_(s1, qs1, qs2, qs3) {}
 
   /// @brief Construct a quaternion from a scalar and 3-dimensional Vector.
   ///
   /// @param s1 Scalar component.
   /// @param v1 Vector component.
-  inline Quaternion(T s1, const Vector<T, 3>& v1)
+  constexpr Quaternion(T s1, const Vector<T, 3>& v1)
       : data_(s1, v1[0], v1[1], v1[2]) {}
 
   /// @brief Return the scalar component of the quaternion.
   ///
   /// @return The scalar component
-  inline T scalar() const { return data_[0]; }
+  constexpr T scalar() const { return data_[0]; }
 
   /// @brief Set the scalar component of the quaternion.
   ///
   /// @param s Scalar component.
-  inline void set_scalar(T s) { data_[0] = s; }
+  constexpr void set_scalar(T s) { data_[0] = s; }
 
   /// @brief Return the vector component of the quaternion.
   ///
   /// @return The vector component
-  inline Vector<T, 3> vector() const {
+  constexpr Vector<T, 3> vector() const {
     return Vector<T, 3>(data_[1], data_[2], data_[3]);
   }
 
   /// @brief Set the vector component of the quaternion.
   ///
   /// @param v Vector component.
-  inline void set_vector(const Vector<T, 3>& v) {
+  constexpr void set_vector(const Vector<T, 3>& v) {
     data_[1] = v[0];
     data_[2] = v[1];
     data_[3] = v[2];
@@ -102,7 +102,7 @@ class Quaternion {
   /// For unit quaternions, the conjugate is equal to the inverse.
   ///
   /// @return Quaternion containing the result.
-  inline Quaternion<T> Conjugate() const {
+  constexpr Quaternion<T> Conjugate() const {
     return Quaternion<T>(data_[0], -data_[1], -data_[2], -data_[3]);
   }
 
@@ -113,7 +113,7 @@ class Quaternion {
   /// for any non-zero quaternion.
   ///
   /// @return Quaternion containing the result.
-  inline Quaternion<T> Inverse() const {
+  constexpr Quaternion<T> Inverse() const {
     T norm_sq = Vector<T, 4>::DotProduct(data_, data_);
     T inv_norm_sq = T(1) / norm_sq;
     return Quaternion<T>(data_[0] * inv_norm_sq, -data_[1] * inv_norm_sq,
@@ -124,7 +124,7 @@ class Quaternion {
   ///
   /// @param q Quaternion to add.
   /// @return Quaternion containing the result.
-  inline Quaternion<T> operator+(const Quaternion<T>& q) const {
+  constexpr Quaternion<T> operator+(const Quaternion<T>& q) const {
     return Quaternion<T>(data_ + q.data_);
   }
 
@@ -132,7 +132,7 @@ class Quaternion {
   ///
   /// @param q Quaternion to add.
   /// @return Quaternion containing the result.
-  inline Quaternion<T>& operator+=(const Quaternion<T>& q) {
+  constexpr Quaternion<T>& operator+=(const Quaternion<T>& q) {
     data_ += q.data_;
     return *this;
   }
@@ -141,7 +141,7 @@ class Quaternion {
   ///
   /// @param q Quaternion to compare against.
   /// @return true if the scalar and vector components are equal.
-  inline bool operator==(const Quaternion<T>& q) const {
+  constexpr bool operator==(const Quaternion<T>& q) const {
     return data_ == q.data_;
   }
 
@@ -149,7 +149,7 @@ class Quaternion {
   ///
   /// @param q Quaternion to compare against.
   /// @return true if the scalar or vector components differ.
-  inline bool operator!=(const Quaternion<T>& q) const { return !(*this == q); }
+  constexpr bool operator!=(const Quaternion<T>& q) const { return !(*this == q); }
 
   /// @brief Multiply this Quaternion with another Quaternion.
   ///
@@ -157,7 +157,7 @@ class Quaternion {
   /// <code>FromMatrix(ToMatrix() * q.ToMatrix()).</code>
   /// @param q Quaternion to multiply with.
   /// @return Quaternion containing the result.
-  inline Quaternion<T> operator*(const Quaternion<T>& q) const {
+  constexpr Quaternion<T> operator*(const Quaternion<T>& q) const {
     const Vector<T, 3> v1 = vector();
     const Vector<T, 3> v2 = q.vector();
     return Quaternion<T>(
@@ -176,7 +176,7 @@ class Quaternion {
   ///
   /// @param s1 Scalar to multiply with.
   /// @return Quaternion containing the result.
-  inline Quaternion<T> operator*(T s1) const {
+  constexpr Quaternion<T> operator*(T s1) const {
     return Quaternion<T>(data_ * s1);
   }
 
@@ -187,7 +187,7 @@ class Quaternion {
   ///
   /// @param s1 Scalar to multiply with.
   /// @return Reference to this Quaternion.
-  inline Quaternion<T>& operator*=(T s1) {
+  constexpr Quaternion<T>& operator*=(T s1) {
     data_ *= s1;
     return *this;
   }
@@ -225,7 +225,7 @@ class Quaternion {
   ///
   /// @param v1 Vector to rotate.
   /// @return Rotated Vector.
-  inline Vector<T, 3> Rotate(const Vector<T, 3>& v1) const {
+  constexpr Vector<T, 3> Rotate(const Vector<T, 3>& v1) const {
     const Vector<T, 3> v = vector();
     T ss = data_[0] + data_[0];
     return ss * Vector<T, 3>::CrossProduct(v, v1) + (ss * data_[0] - T(1)) * v1
@@ -457,7 +457,7 @@ class Quaternion {
   /// @param q1 First quaternion.
   /// @param q2 Second quaternion
   /// @return The scalar dot product of both Quaternions.
-  static inline T DotProduct(const Quaternion<T>& q1, const Quaternion<T>& q2) {
+  static constexpr T DotProduct(const Quaternion<T>& q1, const Quaternion<T>& q2) {
     return Vector<T, 4>::DotProduct(q1.data_, q2.data_);
   }
 
@@ -489,13 +489,13 @@ class Quaternion {
   ///
   /// @param i Index of the element to access.
   /// @return A reference to the accessed element.
-  inline T& operator[](const int i) { return data_[i]; }
+  constexpr T& operator[](const int i) { return data_[i]; }
 
   /// @brief Access an element of the quaternion.
   ///
   /// @param i Index of the element to access.
   /// @return A const reference to the accessed element.
-  inline const T& operator[](const int i) const { return data_[i]; }
+  constexpr const T& operator[](const int i) const { return data_[i]; }
 
   /// @brief Returns a vector that is perpendicular to the supplied vector.
   ///
@@ -503,7 +503,7 @@ class Quaternion {
   /// @return A vector perpendicular to v1.  Normally this will just be
   /// the cross product of v1, v2.  If they are parallel or opposite though,
   /// the routine will attempt to pick a vector.
-  static inline Vector<T, 3> PerpendicularVector(const Vector<T, 3>& v) {
+  static constexpr Vector<T, 3> PerpendicularVector(const Vector<T, 3>& v) {
     // We start out by taking the cross product of the vector and the x-axis to
     // find something parallel to the input vectors.  If that cross product
     // turns out to be length 0 (i. e. the vectors already lie along the x axis)
@@ -697,7 +697,7 @@ Quaternion<T> Quaternion<T>::identity = Quaternion<T>(1, 0, 0, 0);
 ///
 /// @related Quaternion
 template <class T>
-inline Quaternion<T> operator*(T s, const Quaternion<T>& q) {
+constexpr Quaternion<T> operator*(T s, const Quaternion<T>& q) {
   return q * s;
 }
 /// @}

--- a/include/mathfu/ray.h
+++ b/include/mathfu/ray.h
@@ -41,7 +41,7 @@ struct Ray {
   ///
   /// @param origin The origin point of the ray.
   /// @param direction The direction vector of the ray.
-  Ray(const Vector<T, Dims>& origin, const Vector<T, Dims>& direction)
+  constexpr Ray(const Vector<T, Dims>& origin, const Vector<T, Dims>& direction)
       : origin(origin), direction(direction) {}
 
   /// @brief Compute the point at parameter t along the ray.
@@ -49,7 +49,9 @@ struct Ray {
   /// Returns origin + direction * t.
   /// @param t The parameter value.
   /// @return The point at parameter t.
-  Vector<T, Dims> PointAt(T t) const { return origin + direction * t; }
+  constexpr Vector<T, Dims> PointAt(T t) const {
+    return origin + direction * t;
+  }
 
   /// The origin point of the ray.
   Vector<T, Dims> origin;
@@ -64,7 +66,7 @@ struct Ray {
 /// @param r1 Ray to be tested.
 /// @param r2 Other ray to be tested.
 template <class T, int Dims>
-bool operator==(const Ray<T, Dims>& r1, const Ray<T, Dims>& r2) {
+constexpr bool operator==(const Ray<T, Dims>& r1, const Ray<T, Dims>& r2) {
   return (r1.origin == r2.origin && r1.direction == r2.direction);
 }
 
@@ -73,7 +75,7 @@ bool operator==(const Ray<T, Dims>& r1, const Ray<T, Dims>& r2) {
 /// @param r1 Ray to be tested.
 /// @param r2 Other ray to be tested.
 template <class T, int Dims>
-bool operator!=(const Ray<T, Dims>& r1, const Ray<T, Dims>& r2) {
+constexpr bool operator!=(const Ray<T, Dims>& r1, const Ray<T, Dims>& r2) {
   return !(r1 == r2);
 }
 
@@ -98,7 +100,7 @@ struct Line {
   ///
   /// @param point A point on the line.
   /// @param direction The direction vector of the line.
-  Line(const Vector<T, Dims>& point, const Vector<T, Dims>& direction)
+  constexpr Line(const Vector<T, Dims>& point, const Vector<T, Dims>& direction)
       : point(point), direction(direction) {}
 
   /// @brief Create a Line from two points.
@@ -117,7 +119,7 @@ struct Line {
   /// Returns point + direction * t.
   /// @param t The parameter value.
   /// @return The point at parameter t.
-  Vector<T, Dims> PointAt(T t) const { return point + direction * t; }
+  constexpr Vector<T, Dims> PointAt(T t) const { return point + direction * t; }
 
   /// A point on the line.
   Vector<T, Dims> point;
@@ -132,7 +134,7 @@ struct Line {
 /// @param l1 Line to be tested.
 /// @param l2 Other line to be tested.
 template <class T, int Dims>
-bool operator==(const Line<T, Dims>& l1, const Line<T, Dims>& l2) {
+constexpr bool operator==(const Line<T, Dims>& l1, const Line<T, Dims>& l2) {
   return (l1.point == l2.point && l1.direction == l2.direction);
 }
 
@@ -141,7 +143,7 @@ bool operator==(const Line<T, Dims>& l1, const Line<T, Dims>& l2) {
 /// @param l1 Line to be tested.
 /// @param l2 Other line to be tested.
 template <class T, int Dims>
-bool operator!=(const Line<T, Dims>& l1, const Line<T, Dims>& l2) {
+constexpr bool operator!=(const Line<T, Dims>& l1, const Line<T, Dims>& l2) {
   return !(l1 == l2);
 }
 
@@ -165,13 +167,16 @@ struct LineSegment {
   ///
   /// @param start The start point.
   /// @param end The end point.
-  LineSegment(const Vector<T, Dims>& start, const Vector<T, Dims>& end)
+  constexpr LineSegment(const Vector<T, Dims>& start,
+                        const Vector<T, Dims>& end)
       : start(start), end(end) {}
 
   /// @brief Compute the midpoint of the segment.
   ///
   /// @return The center point between start and end.
-  Vector<T, Dims> Center() const { return (start + end) * static_cast<T>(0.5); }
+  constexpr Vector<T, Dims> Center() const {
+    return (start + end) * static_cast<T>(0.5);
+  }
 
   /// @brief Compute the length of the segment.
   ///
@@ -181,7 +186,7 @@ struct LineSegment {
   /// @brief Compute the squared length of the segment.
   ///
   /// @return The squared distance between start and end.
-  T LengthSquared() const { return (end - start).LengthSquared(); }
+  constexpr T LengthSquared() const { return (end - start).LengthSquared(); }
 
   /// @brief Compute the normalized direction from start to end.
   ///
@@ -193,7 +198,7 @@ struct LineSegment {
   ///
   /// @param point The point to find the closest point to.
   /// @return The closest point on the segment to the given point.
-  Vector<T, Dims> ClosestPoint(const Vector<T, Dims>& point) const {
+  constexpr Vector<T, Dims> ClosestPoint(const Vector<T, Dims>& point) const {
     const Vector<T, Dims> segment = end - start;
     const T length_squared = segment.LengthSquared();
     if (length_squared == static_cast<T>(0)) {
@@ -221,8 +226,8 @@ struct LineSegment {
 /// @param s1 LineSegment to be tested.
 /// @param s2 Other LineSegment to be tested.
 template <class T, int Dims>
-bool operator==(const LineSegment<T, Dims>& s1,
-                const LineSegment<T, Dims>& s2) {
+constexpr bool operator==(const LineSegment<T, Dims>& s1,
+                          const LineSegment<T, Dims>& s2) {
   return (s1.start == s2.start && s1.end == s2.end);
 }
 
@@ -231,8 +236,8 @@ bool operator==(const LineSegment<T, Dims>& s1,
 /// @param s1 LineSegment to be tested.
 /// @param s2 Other LineSegment to be tested.
 template <class T, int Dims>
-bool operator!=(const LineSegment<T, Dims>& s1,
-                const LineSegment<T, Dims>& s2) {
+constexpr bool operator!=(const LineSegment<T, Dims>& s1,
+                          const LineSegment<T, Dims>& s2) {
   return !(s1 == s2);
 }
 

--- a/include/mathfu/rect.h
+++ b/include/mathfu/rect.h
@@ -39,7 +39,8 @@ struct Rect {
   /// @brief Create a rect from a vector4 of the same type.
   ///
   /// @param v Vector that the data will be copied from.
-  explicit Rect(const Vector<T, 4>& v) : pos(v.x, v.y), size(v.z, v.w) {}
+  explicit constexpr Rect(const Vector<T, 4>& v)
+      : pos(v.x, v.y), size(v.z, v.w) {}
 
   /// @brief Create a rect from x, y, width and height values.
   ///
@@ -47,38 +48,40 @@ struct Rect {
   /// @param y the given y value.
   /// @param width the given width value.
   /// @param height the given height value.
-  inline Rect(T x = static_cast<T>(0), T y = static_cast<T>(0),
-              T width = static_cast<T>(0), T height = static_cast<T>(0))
+  constexpr Rect(T x = static_cast<T>(0), T y = static_cast<T>(0),
+                 T width = static_cast<T>(0), T height = static_cast<T>(0))
       : pos(x, y), size(width, height) {}
 
   /// @brief Create a rect from two vector2 representing position and size.
   ///
   /// @param pos Vector representing the position vector (x and y values).
   /// @param size Vector represening the size vector (width and height values).
-  inline Rect(const Vector<T, 2>& pos, const Vector<T, 2>& size)
+  constexpr Rect(const Vector<T, 2>& pos, const Vector<T, 2>& size)
       : pos(pos), size(size) {}
 
   /// @brief Returns the center point of the rect.
   ///
   /// @return A Vector<T, 2> at the center of the rect.
-  inline Vector<T, 2> Center() const { return pos + size / static_cast<T>(2); }
+  constexpr Vector<T, 2> Center() const {
+    return pos + size / static_cast<T>(2);
+  }
 
   /// @brief Returns the minimum corner of the rect.
   ///
   /// This is equivalent to the position.
   ///
   /// @return A Vector<T, 2> at the minimum corner (pos).
-  inline Vector<T, 2> Min() const { return pos; }
+  constexpr Vector<T, 2> Min() const { return pos; }
 
   /// @brief Returns the maximum corner of the rect.
   ///
   /// @return A Vector<T, 2> at the maximum corner (pos + size).
-  inline Vector<T, 2> Max() const { return pos + size; }
+  constexpr Vector<T, 2> Max() const { return pos + size; }
 
   /// @brief Returns the area of the rect.
   ///
   /// @return The product of width and height.
-  inline T Area() const { return size.x * size.y; }
+  constexpr T Area() const { return size.x * size.y; }
 
   /// @brief Tests whether a point is contained within the rect.
   ///
@@ -86,7 +89,7 @@ struct Rect {
   ///
   /// @param point The point to test.
   /// @return true if the point is inside or on the boundary of the rect.
-  inline bool Contains(const Vector<T, 2>& point) const {
+  constexpr bool Contains(const Vector<T, 2>& point) const {
     const Vector<T, 2> max = Max();
     return point.x >= pos.x && point.y >= pos.y && point.x <= max.x
            && point.y <= max.y;
@@ -96,7 +99,7 @@ struct Rect {
   ///
   /// @param other The rect to test.
   /// @return true if other is entirely inside or on the boundary of this rect.
-  inline bool Contains(const Rect<T>& other) const {
+  constexpr bool Contains(const Rect<T>& other) const {
     return Contains(other.Min()) && Contains(other.Max());
   }
 
@@ -104,7 +107,7 @@ struct Rect {
   ///
   /// @param other The rect to test.
   /// @return true if the rects overlap.
-  inline bool Intersects(const Rect<T>& other) const {
+  constexpr bool Intersects(const Rect<T>& other) const {
     const Vector<T, 2> this_max = Max();
     const Vector<T, 2> other_max = other.Max();
     return pos.x < other_max.x && this_max.x > other.pos.x
@@ -117,7 +120,7 @@ struct Rect {
   ///
   /// @param other The rect to intersect with.
   /// @return The intersection rect, or a zero-sized rect if no overlap.
-  inline Rect<T> Intersection(const Rect<T>& other) const {
+  constexpr Rect<T> Intersection(const Rect<T>& other) const {
     const Vector<T, 2> max1 = Max();
     const Vector<T, 2> max2 = other.Max();
     const Vector<T, 2> inter_min(std::max(pos.x, other.pos.x),
@@ -134,7 +137,7 @@ struct Rect {
   ///
   /// @param other The rect to union with.
   /// @return The smallest rect containing both this and other.
-  inline Rect<T> Union(const Rect<T>& other) const {
+  constexpr Rect<T> Union(const Rect<T>& other) const {
     const Vector<T, 2> union_min(std::min(pos.x, other.pos.x),
                                  std::min(pos.y, other.pos.y));
     const Vector<T, 2> union_max(std::max(Max().x, other.Max().x),
@@ -148,7 +151,7 @@ struct Rect {
   ///
   /// @param point The point to include.
   /// @return A new rect expanded to contain the point.
-  inline Rect<T> Expand(const Vector<T, 2>& point) const {
+  constexpr Rect<T> Expand(const Vector<T, 2>& point) const {
     const Vector<T, 2> new_min(std::min(pos.x, point.x),
                                std::min(pos.y, point.y));
     const Vector<T, 2> new_max(std::max(Max().x, point.x),
@@ -163,7 +166,7 @@ struct Rect {
   ///
   /// @param amount The amount to expand by.
   /// @return A new rect expanded by the given amount.
-  inline Rect<T> Expand(T amount) const {
+  constexpr Rect<T> Expand(T amount) const {
     return Rect<T>(Vector<T, 2>(pos.x - amount, pos.y - amount),
                    Vector<T, 2>(size.x + static_cast<T>(2) * amount,
                                 size.y + static_cast<T>(2) * amount));
@@ -176,7 +179,7 @@ struct Rect {
 /// @param r1 Rect to be tested.
 /// @param r2 Other rect to be tested.
 template <class T>
-bool operator==(const Rect<T>& r1, const Rect<T>& r2) {
+constexpr bool operator==(const Rect<T>& r1, const Rect<T>& r2) {
   return (r1.pos == r2.pos && r1.size == r2.size);
 }
 
@@ -185,7 +188,7 @@ bool operator==(const Rect<T>& r1, const Rect<T>& r2) {
 /// @param r1 Rect to be tested.
 /// @param r2 Other rect to be tested.
 template <class T>
-bool operator!=(const Rect<T>& r1, const Rect<T>& r2) {
+constexpr bool operator!=(const Rect<T>& r1, const Rect<T>& r2) {
   return !(r1 == r2);
 }
 
@@ -199,7 +202,7 @@ bool operator!=(const Rect<T>& r1, const Rect<T>& r2) {
 /// @param r2 Other rect to be tested.
 /// @return true if @p r1 is lexicographically less than @p r2.
 template <class T>
-bool operator<(const Rect<T>& r1, const Rect<T>& r2) {
+constexpr bool operator<(const Rect<T>& r1, const Rect<T>& r2) {
   if (r1.pos != r2.pos) return r1.pos < r2.pos;
   return r1.size < r2.size;
 }

--- a/include/mathfu/sphere.h
+++ b/include/mathfu/sphere.h
@@ -56,14 +56,14 @@ struct Sphere {
   ///
   /// @param center The center point of the sphere.
   /// @param radius The radius of the sphere.
-  inline Sphere(const Vector<T, N>& center, T radius)
+  constexpr Sphere(const Vector<T, N>& center, T radius)
       : center(center), radius(radius) {}
 
   /// @brief Check whether a point is inside (or on the boundary of) the sphere.
   ///
   /// @param point The point to test.
   /// @return true if the point is inside the sphere, false otherwise.
-  inline bool Contains(const Vector<T, N>& point) const {
+  constexpr bool Contains(const Vector<T, N>& point) const {
     return Vector<T, N>::DistanceSquared(center, point) <= radius * radius;
   }
 
@@ -81,7 +81,7 @@ struct Sphere {
   ///
   /// @param other The sphere to test for intersection.
   /// @return true if the spheres overlap, false otherwise.
-  inline bool Intersects(const Sphere<T, N>& other) const {
+  constexpr bool Intersects(const Sphere<T, N>& other) const {
     T sum_radii = radius + other.radius;
     return Vector<T, N>::DistanceSquared(center, other.center)
            <= sum_radii * sum_radii;
@@ -90,7 +90,7 @@ struct Sphere {
   /// @brief Calculate the area of a 2D circle (N=2).
   ///
   /// @return The area of the circle (pi * r^2).
-  inline T Area() const {
+  constexpr T Area() const {
     static_assert(N == 2, "Area() is only defined for 2D circles (N=2).");
     return std::numbers::pi_v<T> * radius * radius;
   }
@@ -98,7 +98,7 @@ struct Sphere {
   /// @brief Calculate the volume of a 3D sphere (N=3).
   ///
   /// @return The volume of the sphere (4/3 * pi * r^3).
-  inline T Volume() const {
+  constexpr T Volume() const {
     static_assert(N == 3, "Volume() is only defined for 3D spheres (N=3).");
     return (static_cast<T>(4) / static_cast<T>(3)) * std::numbers::pi_v<T>
            * radius * radius * radius;
@@ -107,7 +107,7 @@ struct Sphere {
   /// @brief Calculate the diameter of the sphere.
   ///
   /// @return The diameter (2 * radius).
-  inline T Diameter() const { return static_cast<T>(2) * radius; }
+  constexpr T Diameter() const { return static_cast<T>(2) * radius; }
 };
 /// @}
 
@@ -116,7 +116,7 @@ struct Sphere {
 /// @param s1 Sphere to be tested.
 /// @param s2 Other sphere to be tested.
 template <class T, int N>
-bool operator==(const Sphere<T, N>& s1, const Sphere<T, N>& s2) {
+constexpr bool operator==(const Sphere<T, N>& s1, const Sphere<T, N>& s2) {
   return (s1.center == s2.center && s1.radius == s2.radius);
 }
 
@@ -125,7 +125,7 @@ bool operator==(const Sphere<T, N>& s1, const Sphere<T, N>& s2) {
 /// @param s1 Sphere to be tested.
 /// @param s2 Other sphere to be tested.
 template <class T, int N>
-bool operator!=(const Sphere<T, N>& s1, const Sphere<T, N>& s2) {
+constexpr bool operator!=(const Sphere<T, N>& s1, const Sphere<T, N>& s2) {
   return !(s1 == s2);
 }
 

--- a/include/mathfu/transform.h
+++ b/include/mathfu/transform.h
@@ -61,8 +61,8 @@ struct Transform {
   /// @param position Position vector.
   /// @param rotation Rotation quaternion.
   /// @param scale Scale vector.
-  inline Transform(const Vector<T, 3>& position, const Quaternion<T>& rotation,
-                   const Vector<T, 3>& scale)
+  constexpr Transform(const Vector<T, 3>& position,
+                      const Quaternion<T>& rotation, const Vector<T, 3>& scale)
       : position(position), rotation(rotation), scale(scale) {}
 
   /// @brief Create a transform from position only.
@@ -81,7 +81,8 @@ struct Transform {
   ///
   /// @param position Position vector.
   /// @param rotation Rotation quaternion.
-  inline Transform(const Vector<T, 3>& position, const Quaternion<T>& rotation)
+  constexpr Transform(const Vector<T, 3>& position,
+                      const Quaternion<T>& rotation)
       : position(position), rotation(rotation), scale(T(1), T(1), T(1)) {}
 
   /// @brief Convert this transform to a 4x4 matrix.
@@ -100,7 +101,7 @@ struct Transform {
   ///
   /// @param point The point to transform.
   /// @return The transformed point.
-  inline Vector<T, 3> TransformPoint(const Vector<T, 3>& point) const {
+  constexpr Vector<T, 3> TransformPoint(const Vector<T, 3>& point) const {
     return rotation.Rotate(Vector<T, 3>(point.x * scale.x, point.y * scale.y,
                                         point.z * scale.z))
            + position;
@@ -112,10 +113,10 @@ struct Transform {
   ///
   /// @param direction The direction vector to transform.
   /// @return The transformed direction.
-  inline Vector<T, 3> TransformDirection(const Vector<T, 3>& direction) const {
-    return rotation.Rotate(Vector<T, 3>(direction.x * scale.x,
-                                        direction.y * scale.y,
-                                        direction.z * scale.z));
+  constexpr Vector<T, 3> TransformDirection(
+      const Vector<T, 3>& direction) const {
+    return rotation.Rotate(Vector<T, 3>(
+        direction.x * scale.x, direction.y * scale.y, direction.z * scale.z));
   }
 
   /// @brief Compute the inverse of this transform.
@@ -128,7 +129,7 @@ struct Transform {
   /// is introduced because TRS decomposition is lossy for sheared matrices.
   ///
   /// @return The inverse transform.
-  inline Transform<T> Inverse() const {
+  constexpr Transform<T> Inverse() const {
     Quaternion<T> inv_rotation = rotation.Inverse();
     Vector<T, 3> inv_scale(T(1) / scale.x, T(1) / scale.y, T(1) / scale.z);
     // The inverse of T*R*S applied to a point:
@@ -156,7 +157,7 @@ struct Transform {
   ///
   /// @param rhs Transform to compose with.
   /// @return The composed transform.
-  inline Transform<T> operator*(const Transform<T>& rhs) const {
+  constexpr Transform<T> operator*(const Transform<T>& rhs) const {
     // Composing T1*R1*S1 with T2*R2*S2:
     //   position: r1 * (s1 .* rhs.position) + p1
     //   rotation: r1 * r2
@@ -182,7 +183,7 @@ struct Transform {
 /// @param t1 Transform to be tested.
 /// @param t2 Other transform to be tested.
 template <class T>
-bool operator==(const Transform<T>& t1, const Transform<T>& t2) {
+constexpr bool operator==(const Transform<T>& t1, const Transform<T>& t2) {
   return t1.position == t2.position && t1.rotation == t2.rotation
          && t1.scale == t2.scale;
 }
@@ -192,7 +193,7 @@ bool operator==(const Transform<T>& t1, const Transform<T>& t2) {
 /// @param t1 Transform to be tested.
 /// @param t2 Other transform to be tested.
 template <class T>
-bool operator!=(const Transform<T>& t1, const Transform<T>& t2) {
+constexpr bool operator!=(const Transform<T>& t1, const Transform<T>& t2) {
   return !(t1 == t2);
 }
 /// @}

--- a/include/mathfu/utilities.h
+++ b/include/mathfu/utilities.h
@@ -240,7 +240,7 @@ static constexpr const char *kVersion = "2.0.0";
 /// @param upper Upper value of the range.
 /// @returns Clamped value.
 template <class T>
-T Clamp(const T &x, const T &lower, const T &upper) {
+constexpr T Clamp(const T &x, const T &lower, const T &upper) {
   return std::max<T>(lower, std::min<T>(x, upper));
 }
 
@@ -259,7 +259,7 @@ T Clamp(const T &x, const T &lower, const T &upper) {
 /// @tparam T2 Type of the value used to perform interpolation
 ///         (e.g float or double).
 template <class T, class T2>
-T Lerp(const T &range_start, const T &range_end, const T2 &percent) {
+constexpr T Lerp(const T &range_start, const T &range_end, const T2 &percent) {
   return range_start + (range_end - range_start) * percent;
 }
 
@@ -276,7 +276,7 @@ T Lerp(const T &range_start, const T &range_end, const T2 &percent) {
 ///
 /// @tparam T Type of the range to interpolate over.
 template <class T>
-T Lerp(const T &range_start, const T &range_end, const T &percent) {
+constexpr T Lerp(const T &range_start, const T &range_end, const T &percent) {
   return Lerp<T, T>(range_start, range_end, percent);
 }
 
@@ -290,7 +290,7 @@ T Lerp(const T &range_start, const T &range_end, const T &percent) {
 ///
 /// @tparam T Type of values to test.
 template <class T>
-bool InRange(T val, T range_start, T range_end) {
+constexpr bool InRange(T val, T range_start, T range_end) {
   return val >= range_start && val < range_end;
 }
 
@@ -308,7 +308,7 @@ bool InRange(T val, T range_start, T range_end) {
 /// @param x Value to round up. Must be non-negative for signed types.
 /// @returns Value rounded up to the nearest power of 2.
 template <std::integral T>
-T RoundUpToPowerOf2(T x) {
+constexpr T RoundUpToPowerOf2(T x) {
   // Use unsigned arithmetic to avoid undefined behavior with signed shifts.
   typedef typename std::make_unsigned<T>::type U;
   if (x <= 1) return x;
@@ -350,7 +350,7 @@ T RoundUpToPowerOf2(T x) {
 /// @param v Value to round up.
 /// @returns Value rounded up to the type's alignment boundary.
 template <typename T>
-size_t RoundUpToTypeBoundary(size_t v) {
+constexpr size_t RoundUpToTypeBoundary(size_t v) {
   static_assert((alignof(T) & (alignof(T) - 1)) == 0,
                 "alignof(T) must be a power of 2");
   return (v + alignof(T) - 1) & ~(alignof(T) - 1);

--- a/include/mathfu/vector.h
+++ b/include/mathfu/vector.h
@@ -66,17 +66,17 @@ class Vector;
 
 /// @cond MATHFU_INTERNAL
 template <class T, int Dims>
-static inline T DotProductHelper(const Vector<T, Dims>& v1,
-                                 const Vector<T, Dims>& v2);
+static constexpr T DotProductHelper(const Vector<T, Dims>& v1,
+                                    const Vector<T, Dims>& v2);
 template <class T>
-static inline T DotProductHelper(const Vector<T, 2>& v1,
-                                 const Vector<T, 2>& v2);
+static constexpr T DotProductHelper(const Vector<T, 2>& v1,
+                                    const Vector<T, 2>& v2);
 template <class T>
-static inline T DotProductHelper(const Vector<T, 3>& v1,
-                                 const Vector<T, 3>& v2);
+static constexpr T DotProductHelper(const Vector<T, 3>& v1,
+                                    const Vector<T, 3>& v2);
 template <class T>
-static inline T DotProductHelper(const Vector<T, 4>& v1,
-                                 const Vector<T, 4>& v2);
+static constexpr T DotProductHelper(const Vector<T, 4>& v1,
+                                    const Vector<T, 4>& v2);
 
 template <typename T, int Dims, typename CompatibleT>
 static inline Vector<T, Dims> FromTypeHelper(const CompatibleT& compatible);
@@ -153,8 +153,8 @@ struct VectorPacked {
 ///
 /// @return true if all elements are equal, false otherwise.
 template <class T, int Dims>
-inline bool operator==(const VectorPacked<T, Dims>& lhs,
-                       const VectorPacked<T, Dims>& rhs) {
+constexpr bool operator==(const VectorPacked<T, Dims>& lhs,
+                          const VectorPacked<T, Dims>& rhs) {
   for (int i = 0; i < Dims; ++i) {
     if (lhs.data_[i] != rhs.data_[i]) return false;
   }
@@ -165,8 +165,8 @@ inline bool operator==(const VectorPacked<T, Dims>& lhs,
 ///
 /// @return true if any elements differ, false otherwise.
 template <class T, int Dims>
-inline bool operator!=(const VectorPacked<T, Dims>& lhs,
-                       const VectorPacked<T, Dims>& rhs) {
+constexpr bool operator!=(const VectorPacked<T, Dims>& lhs,
+                          const VectorPacked<T, Dims>& rhs) {
   return !(lhs == rhs);
 }
 /// @}
@@ -194,12 +194,12 @@ class Vector {
   /// The elements of the Vector are left uninitialized and have indeterminate
   /// values. This is intentional for performance: use Vector(T) or one of the
   /// component constructors if you need specific values.
-  inline Vector() {}
+  constexpr Vector() {}
 
   /// @brief Create a vector from another vector copying each element.
   ///
   /// @param v Vector that the data will be copied from.
-  inline Vector(const Vector<T, Dims>& v) {
+  constexpr Vector(const Vector<T, Dims>& v) {
     MATHFU_VECTOR_OPERATION(data_[i] = v.data_[i]);
   }
 
@@ -211,7 +211,7 @@ class Vector {
   /// @param v Vector that the data will be copied from.
   /// @tparam U type of Vector elements to copy.
   template <typename U>
-  explicit inline Vector(const Vector<U, Dims>& v) {
+  explicit constexpr Vector(const Vector<U, Dims>& v) {
     MATHFU_VECTOR_OPERATION(data_[i] = static_cast<T>(v[i]));
   }
 
@@ -219,12 +219,12 @@ class Vector {
   ///
   /// Each elements is set to be equal to the value given.
   /// @param s Scalar value that the vector will be initialized to.
-  explicit inline Vector(T s) { MATHFU_VECTOR_OPERATION(data_[i] = s); }
+  explicit constexpr Vector(T s) { MATHFU_VECTOR_OPERATION(data_[i] = s); }
 
   /// @brief Create a vector form the first Dims elements of an array.
   ///
   /// @param a Array of values that the vector will be iniitlized to.
-  explicit inline Vector(const T* a) {
+  explicit constexpr Vector(const T* a) {
     MATHFU_VECTOR_OPERATION(data_[i] = a[i]);
   }
 
@@ -234,7 +234,7 @@ class Vector {
   ///
   /// @param s1 Scalar value for the first element of the vector.
   /// @param s2 Scalar value for the second element of the vector.
-  inline Vector(T s1, T s2) {
+  constexpr Vector(T s1, T s2) {
     static_assert(Dims == 2, "Dims must be 2");
     data_[0] = s1;
     data_[1] = s2;
@@ -247,7 +247,7 @@ class Vector {
   /// @param s1 Scalar value for the first element of the vector.
   /// @param s2 Scalar value for the second element of the vector.
   /// @param s3 Scalar value for the third element of the vector.
-  inline Vector(T s1, T s2, T s3) {
+  constexpr Vector(T s1, T s2, T s3) {
     static_assert(Dims == 3, "Dims must be 3");
     data_[0] = s1;
     data_[1] = s2;
@@ -260,7 +260,7 @@ class Vector {
   ///
   /// @param v12 Vector containing the first 2 values.
   /// @param s3 Scalar value for the third element of the vector.
-  inline Vector(const Vector<T, 2>& v12, T s3) {
+  constexpr Vector(const Vector<T, 2>& v12, T s3) {
     static_assert(Dims == 3, "Dims must be 3");
     data_[0] = v12[0];
     data_[1] = v12[1];
@@ -275,7 +275,7 @@ class Vector {
   /// @param s2 Scalar value for the second element of the vector.
   /// @param s3 Scalar value for the third element of the vector.
   /// @param s4 Scalar value for the forth element of the vector.
-  inline Vector(T s1, T s2, T s3, T s4) {
+  constexpr Vector(T s1, T s2, T s3, T s4) {
     static_assert(Dims == 4, "Dims must be 4");
     data_[0] = s1;
     data_[1] = s2;
@@ -290,7 +290,7 @@ class Vector {
   ///
   /// @param vector3 Vector used to initialize the first 3 elements.
   /// @param value Value used to set the last element of the vector.
-  inline Vector(const Vector<T, 3>& vector123, T s4) {
+  constexpr Vector(const Vector<T, 3>& vector123, T s4) {
     static_assert(Dims == 4, "Dims must be 4");
     data_[0] = vector123[0];
     data_[1] = vector123[1];
@@ -304,7 +304,7 @@ class Vector {
   ///
   /// @param v12 Vector containing the first 2 values.
   /// @param v34 Vector containing the last 2 values.
-  inline Vector(const Vector<T, 2>& v12, const Vector<T, 2>& v34) {
+  constexpr Vector(const Vector<T, 2>& v12, const Vector<T, 2>& v34) {
     static_assert(Dims == 4, "Dims must be 4");
     data_[0] = v12[0];
     data_[1] = v12[1];
@@ -315,7 +315,7 @@ class Vector {
   /// @brief Create a vector from packed vector (VectorPacked).
   ///
   /// @param vector Packed vector used to initialize an unpacked.
-  explicit inline Vector(const VectorPacked<T, Dims>& vector) {
+  explicit constexpr Vector(const VectorPacked<T, Dims>& vector) {
     MATHFU_VECTOR_OPERATION(data_[i] = vector.data_[i]);
   }
 
@@ -324,32 +324,32 @@ class Vector {
   /// @param i Index of the element to access.
   /// @return A reference to the accessed data that can be modified by the
   /// caller.
-  inline T& operator()(const int i) { return data_[i]; }
+  constexpr T& operator()(const int i) { return data_[i]; }
 
   /// @brief Access an element of the vector.
   ///
   /// @param i Index of the element to access.
   /// @return A reference to the accessed data.
-  inline const T& operator()(const int i) const { return data_[i]; }
+  constexpr const T& operator()(const int i) const { return data_[i]; }
 
   /// @brief Access an element of the vector.
   ///
   /// @param i Index of the element to access.
   /// @return A reference to the accessed data that can be modified by the
   /// caller.
-  inline T& operator[](const int i) { return data_[i]; }
+  constexpr T& operator[](const int i) { return data_[i]; }
 
   /// @brief Access an element of the vector.
   ///
   /// @param i Index of the element to access.
   /// @return A const reference to the accessed.
-  inline const T& operator[](const int i) const { return data_[i]; }
+  constexpr const T& operator[](const int i) const { return data_[i]; }
 
   /// @brief Access the first element of the vector.
   ///
   /// @note This method only works with vectors of 1 or more dimensions.
   /// @return A reference to the first element.
-  inline T& x() {
+  constexpr T& x() {
     static_assert(Dims >= 1, "x() requires >= 1D");
     return data_[0];
   }
@@ -358,7 +358,7 @@ class Vector {
   ///
   /// @note This method only works with vectors of 1 or more dimensions.
   /// @return A const reference to the first element.
-  inline const T& x() const {
+  constexpr const T& x() const {
     static_assert(Dims >= 1, "x() requires >= 1D");
     return data_[0];
   }
@@ -367,7 +367,7 @@ class Vector {
   ///
   /// @note This method only works with vectors of 2 or more dimensions.
   /// @return A reference to the second element.
-  inline T& y() {
+  constexpr T& y() {
     static_assert(Dims >= 2, "y() requires >= 2D");
     return data_[1];
   }
@@ -376,7 +376,7 @@ class Vector {
   ///
   /// @note This method only works with vectors of 2 or more dimensions.
   /// @return A const reference to the second element.
-  inline const T& y() const {
+  constexpr const T& y() const {
     static_assert(Dims >= 2, "y() requires >= 2D");
     return data_[1];
   }
@@ -385,7 +385,7 @@ class Vector {
   ///
   /// @note This method only works with vectors of 3 or more dimensions.
   /// @return A reference to the third element.
-  inline T& z() {
+  constexpr T& z() {
     static_assert(Dims >= 3, "z() requires >= 3D");
     return data_[2];
   }
@@ -394,7 +394,7 @@ class Vector {
   ///
   /// @note This method only works with vectors of 3 or more dimensions.
   /// @return A const reference to the third element.
-  inline const T& z() const {
+  constexpr const T& z() const {
     static_assert(Dims >= 3, "z() requires >= 3D");
     return data_[2];
   }
@@ -403,7 +403,7 @@ class Vector {
   ///
   /// @note This method only works with vectors of 4 or more dimensions.
   /// @return A reference to the fourth element.
-  inline T& w() {
+  constexpr T& w() {
     static_assert(Dims >= 4, "w() requires >= 4D");
     return data_[3];
   }
@@ -412,7 +412,7 @@ class Vector {
   ///
   /// @note This method only works with vectors of 4 or more dimensions.
   /// @return A const reference to the fourth element.
-  inline const T& w() const {
+  constexpr const T& w() const {
     static_assert(Dims >= 4, "w() requires >= 4D");
     return data_[3];
   }
@@ -422,7 +422,7 @@ class Vector {
   /// This only works with vectors that contain more than 3 elements.
   /// @returns A 3-dimensional Vector containing the first 3 elements of
   // this Vector.
-  inline Vector<T, 3> xyz() {
+  constexpr Vector<T, 3> xyz() {
     static_assert(Dims > 3, "Dims must be greater than 3");
     return Vector<T, 3>(data_[0], data_[1], data_[2]);
   }
@@ -432,7 +432,7 @@ class Vector {
   /// This only works with vectors that contain more than 3 elements.
   /// @returns A 3-dimensional Vector containing the first 3 elements of
   // this Vector.
-  inline const Vector<T, 3> xyz() const {
+  constexpr const Vector<T, 3> xyz() const {
     static_assert(Dims > 3, "Dims must be greater than 3");
     return Vector<T, 3>(data_[0], data_[1], data_[2]);
   }
@@ -441,7 +441,7 @@ class Vector {
   ///
   /// This only works with vectors that contain more than 2 elements.
   /// @returns A 2-dimensional Vector with the first 2 elements of this Vector.
-  inline Vector<T, 2> xy() {
+  constexpr Vector<T, 2> xy() {
     static_assert(Dims > 2, "Dims must be greater than 2");
     return Vector<T, 2>(data_[0], data_[1]);
   }
@@ -450,7 +450,7 @@ class Vector {
   ///
   /// This only works with vectors that contain more than 2 elements.
   /// @returns A 2-dimensional Vector with the first 2 elements of this Vector.
-  inline const Vector<T, 2> xy() const {
+  constexpr const Vector<T, 2> xy() const {
     static_assert(Dims > 2, "Dims must be greater than 2");
     return Vector<T, 2>(data_[0], data_[1]);
   }
@@ -459,7 +459,7 @@ class Vector {
   ///
   /// This only works with vectors that contain 4 elements.
   /// @returns A 2-dimensional Vector with the last 2 elements of this Vector.
-  inline Vector<T, 2> zw() {
+  constexpr Vector<T, 2> zw() {
     static_assert(Dims == 4, "Dims must be 4");
     return Vector<T, 2>(data_[2], data_[3]);
   }
@@ -468,7 +468,7 @@ class Vector {
   ///
   /// This only works with vectors that contain 4 elements.
   /// @returns A 2-dimensional Vector with the last 2 elements of this Vector.
-  inline const Vector<T, 2> zw() const {
+  constexpr const Vector<T, 2> zw() const {
     static_assert(Dims == 4, "Dims must be 4");
     return Vector<T, 2>(data_[2], data_[3]);
   }
@@ -476,14 +476,14 @@ class Vector {
   /// @brief Pack a Vector to a packed "Dims" element vector structure.
   ///
   /// @param vector Packed "Dims" element vector to write to.
-  inline void Pack(VectorPacked<T, Dims>* const vector) const {
+  constexpr void Pack(VectorPacked<T, Dims>* const vector) const {
     MATHFU_VECTOR_OPERATION(vector->data_[i] = data_[i]);
   }
 
   /// @brief Calculate the squared length of this vector.
   ///
   /// @return The length of this vector squared.
-  inline T LengthSquared() const { return LengthSquaredHelper(*this); }
+  constexpr T LengthSquared() const { return LengthSquaredHelper(*this); }
 
   /// @brief Calculate the length of this vector.
   ///
@@ -537,8 +537,8 @@ class Vector {
   /// @param v1 First vector.
   /// @param v2 Second vector.
   /// @return The dot product of v1 and v2.
-  static inline T DotProduct(const Vector<T, Dims>& v1,
-                             const Vector<T, Dims>& v2) {
+  static constexpr T DotProduct(const Vector<T, Dims>& v1,
+                                const Vector<T, Dims>& v2) {
     return DotProductHelper(v1, v2);
   }
 
@@ -547,8 +547,8 @@ class Vector {
   /// @param v1 First vector.
   /// @param v2 Second vector.
   /// @return The hadamard product of v1 and v2.
-  static inline Vector<T, Dims> HadamardProduct(const Vector<T, Dims>& v1,
-                                                const Vector<T, Dims>& v2) {
+  static constexpr Vector<T, Dims> HadamardProduct(const Vector<T, Dims>& v1,
+                                                   const Vector<T, Dims>& v2) {
     return HadamardProductHelper(v1, v2);
   }
 
@@ -557,8 +557,8 @@ class Vector {
   /// @param v1 First vector (numerator).
   /// @param v2 Second vector (denominator).
   /// @return The componentwise quotient of v1 and v2.
-  static inline Vector<T, Dims> HadamardDivide(const Vector<T, Dims>& v1,
-                                               const Vector<T, Dims>& v2) {
+  static constexpr Vector<T, Dims> HadamardDivide(const Vector<T, Dims>& v1,
+                                                  const Vector<T, Dims>& v2) {
     return HadamardDivideHelper(v1, v2);
   }
 
@@ -568,8 +568,8 @@ class Vector {
   /// @param v1 First vector.
   /// @param v2 Second vector.
   /// @return The cross product of v1 and v2.
-  static inline Vector<T, 3> CrossProduct(const Vector<T, 3>& v1,
-                                          const Vector<T, 3>& v2) {
+  static constexpr Vector<T, 3> CrossProduct(const Vector<T, 3>& v1,
+                                             const Vector<T, 3>& v2) {
     return CrossProductHelper(v1, v2);
   }
 
@@ -580,7 +580,8 @@ class Vector {
   /// @param v1 First vector.
   /// @param v2 Second vector.
   /// @return The scalar cross product of v1 and v2.
-  static inline T CrossProduct(const Vector<T, 2>& v1, const Vector<T, 2>& v2) {
+  static constexpr T CrossProduct(const Vector<T, 2>& v1,
+                                  const Vector<T, 2>& v2) {
     return CrossProductHelper(v1, v2);
   }
 
@@ -590,9 +591,9 @@ class Vector {
   /// @param v2 Second vector.
   /// @param percent Percentage from v1 to v2 in range 0.0...1.0.
   /// @return The hadamard product of v1 and v2.
-  static inline Vector<T, Dims> Lerp(const Vector<T, Dims>& v1,
-                                     const Vector<T, Dims>& v2,
-                                     const T percent) {
+  static constexpr Vector<T, Dims> Lerp(const Vector<T, Dims>& v1,
+                                        const Vector<T, Dims>& v2,
+                                        const T percent) {
     return LerpHelper(v1, v2, percent);
   }
 
@@ -601,8 +602,8 @@ class Vector {
   /// @param v1 First vector.
   /// @param v2 Second vector.
   /// @return Max value of v1 and v2.
-  static inline Vector<T, Dims> Max(const Vector<T, Dims>& v1,
-                                    const Vector<T, Dims>& v2) {
+  static constexpr Vector<T, Dims> Max(const Vector<T, Dims>& v1,
+                                       const Vector<T, Dims>& v2) {
     return MaxHelper(v1, v2);
   }
 
@@ -611,8 +612,8 @@ class Vector {
   /// @param v1 First vector.
   /// @param v2 Second vector.
   /// @return Min value of v1 and v2.
-  static inline Vector<T, Dims> Min(const Vector<T, Dims>& v1,
-                                    const Vector<T, Dims>& v2) {
+  static constexpr Vector<T, Dims> Min(const Vector<T, Dims>& v1,
+                                       const Vector<T, Dims>& v2) {
     return MinHelper(v1, v2);
   }
 
@@ -623,9 +624,9 @@ class Vector {
   /// @param range_start Starting point of the range (inclusive).
   /// @param range_end Ending point of the range (non-inclusive).
   /// @return Bool indicating val is in range for every component.
-  static inline bool InRange(const Vector<T, Dims>& val,
-                             const Vector<T, Dims>& range_start,
-                             const Vector<T, Dims>& range_end) {
+  static constexpr bool InRange(const Vector<T, Dims>& val,
+                                const Vector<T, Dims>& range_start,
+                                const Vector<T, Dims>& range_end) {
     return InRangeHelper(val, range_start, range_end);
   }
 
@@ -644,8 +645,8 @@ class Vector {
   /// @param v1 First vector.
   /// @param v2 Second vector.
   /// @return Squared distance between vectors v1 and v2.
-  static inline T DistanceSquared(const Vector<T, Dims>& v1,
-                                  const Vector<T, Dims>& v2) {
+  static constexpr T DistanceSquared(const Vector<T, Dims>& v1,
+                                     const Vector<T, Dims>& v2) {
     return (v1 - v2).LengthSquared();
   }
 
@@ -664,8 +665,8 @@ class Vector {
   /// @param v The vector to project.
   /// @param onto The vector to project onto. Must be non-zero.
   /// @return The vector projection of v onto onto.
-  static inline Vector<T, Dims> Project(const Vector<T, Dims>& v,
-                                        const Vector<T, Dims>& onto) {
+  static constexpr Vector<T, Dims> Project(const Vector<T, Dims>& v,
+                                           const Vector<T, Dims>& onto) {
     return ProjectHelper(v, onto);
   }
 
@@ -675,8 +676,8 @@ class Vector {
   /// @param v The vector to reject.
   /// @param from The vector to reject from. Must be non-zero.
   /// @return The vector rejection of v from from.
-  static inline Vector<T, Dims> Reject(const Vector<T, Dims>& v,
-                                       const Vector<T, Dims>& from) {
+  static constexpr Vector<T, Dims> Reject(const Vector<T, Dims>& v,
+                                          const Vector<T, Dims>& from) {
     return RejectHelper(v, from);
   }
 
@@ -686,8 +687,8 @@ class Vector {
   /// @param normal The surface normal (must be normalized).
   /// @return The reflected direction.
   /// Matches GLSL reflect() semantics.
-  static inline Vector<T, Dims> Reflect(const Vector<T, Dims>& incident,
-                                        const Vector<T, Dims>& normal) {
+  static constexpr Vector<T, Dims> Reflect(const Vector<T, Dims>& incident,
+                                           const Vector<T, Dims>& normal) {
     return ReflectHelper(incident, normal);
   }
 
@@ -723,7 +724,8 @@ class Vector {
 ///
 /// @return true if the 2 vectors contains the same value, false otherwise.
 template <class T, int Dims>
-inline bool operator==(const Vector<T, Dims>& lhs, const Vector<T, Dims>& rhs) {
+constexpr bool operator==(const Vector<T, Dims>& lhs,
+                          const Vector<T, Dims>& rhs) {
   for (int i = 0; i < Dims; ++i) {
     if (lhs[i] != rhs[i]) return false;
   }
@@ -734,7 +736,8 @@ inline bool operator==(const Vector<T, Dims>& lhs, const Vector<T, Dims>& rhs) {
 ///
 /// @return true if the elements of two vectors differ, false otherwise.
 template <class T, int Dims>
-inline bool operator!=(const Vector<T, Dims>& lhs, const Vector<T, Dims>& rhs) {
+constexpr bool operator!=(const Vector<T, Dims>& lhs,
+                          const Vector<T, Dims>& rhs) {
   return !(lhs == rhs);
 }
 
@@ -748,7 +751,8 @@ inline bool operator!=(const Vector<T, Dims>& lhs, const Vector<T, Dims>& rhs) {
 ///
 /// @return true if @p lhs is lexicographically less than @p rhs.
 template <class T, int Dims>
-inline bool operator<(const Vector<T, Dims>& lhs, const Vector<T, Dims>& rhs) {
+constexpr bool operator<(const Vector<T, Dims>& lhs,
+                         const Vector<T, Dims>& rhs) {
   for (int i = 0; i < Dims; ++i) {
     if (lhs[i] < rhs[i]) return true;
     if (rhs[i] < lhs[i]) return false;
@@ -760,7 +764,7 @@ inline bool operator<(const Vector<T, Dims>& lhs, const Vector<T, Dims>& rhs) {
 ///
 /// @return A new Vector containing the result.
 template <class T, int Dims>
-inline Vector<T, Dims> operator-(const Vector<T, Dims>& v) {
+constexpr Vector<T, Dims> operator-(const Vector<T, Dims>& v) {
   MATHFU_VECTOR_OPERATOR(-v.data_[i]);
 }
 
@@ -773,7 +777,7 @@ inline Vector<T, Dims> operator-(const Vector<T, Dims>& v) {
 /// @return Vector containing the result.
 /// @related Vector
 template <class T, int Dims>
-inline Vector<T, Dims> operator*(T s, const Vector<T, Dims>& v) {
+constexpr Vector<T, Dims> operator*(T s, const Vector<T, Dims>& v) {
   MATHFU_VECTOR_OPERATOR(v.data_[i] * s);
 }
 
@@ -786,7 +790,7 @@ inline Vector<T, Dims> operator*(T s, const Vector<T, Dims>& v) {
 /// @return Vector containing the result.
 /// @related Vector
 template <class T, int Dims>
-inline Vector<T, Dims> operator/(const Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims> operator/(const Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATOR(v.data_[i] / s);
 }
 
@@ -799,7 +803,7 @@ inline Vector<T, Dims> operator/(const Vector<T, Dims>& v, T s) {
 /// @return Vector containing the result.
 /// @related Vector
 template <class T, int Dims>
-inline Vector<T, Dims> operator/(const T& s, const Vector<T, Dims>& v) {
+constexpr Vector<T, Dims> operator/(const T& s, const Vector<T, Dims>& v) {
   MATHFU_VECTOR_OPERATOR(s / v.data_[i]);
 }
 
@@ -810,7 +814,7 @@ inline Vector<T, Dims> operator/(const T& s, const Vector<T, Dims>& v) {
 /// @return Vector containing the result.
 /// @related Vector
 template <class T, int Dims>
-inline Vector<T, Dims> operator+(T s, const Vector<T, Dims>& v) {
+constexpr Vector<T, Dims> operator+(T s, const Vector<T, Dims>& v) {
   MATHFU_VECTOR_OPERATOR(v.data_[i] + s);
 }
 
@@ -821,7 +825,7 @@ inline Vector<T, Dims> operator+(T s, const Vector<T, Dims>& v) {
 /// @return Vector containing the result.
 /// @related Vector
 template <class T, int Dims>
-inline Vector<T, Dims> operator-(T s, const Vector<T, Dims>& v) {
+constexpr Vector<T, Dims> operator-(T s, const Vector<T, Dims>& v) {
   MATHFU_VECTOR_OPERATOR(s - v.data_[i]);
 }
 
@@ -831,8 +835,8 @@ inline Vector<T, Dims> operator-(T s, const Vector<T, Dims>& v) {
 /// @param rhs Second vector to add by.
 /// @return A new vector containing the result.
 template <class T, int Dims>
-inline Vector<T, Dims> operator+(const Vector<T, Dims>& lhs,
-                                 const Vector<T, Dims>& rhs) {
+constexpr Vector<T, Dims> operator+(const Vector<T, Dims>& lhs,
+                                    const Vector<T, Dims>& rhs) {
   MATHFU_VECTOR_OPERATOR(lhs.data_[i] + rhs[i]);
 }
 
@@ -842,8 +846,8 @@ inline Vector<T, Dims> operator+(const Vector<T, Dims>& lhs,
 /// @param rhs Second vector to subtract by.
 /// @return A new vector containing the result.
 template <class T, int Dims>
-inline Vector<T, Dims> operator-(const Vector<T, Dims>& lhs,
-                                 const Vector<T, Dims>& rhs) {
+constexpr Vector<T, Dims> operator-(const Vector<T, Dims>& lhs,
+                                    const Vector<T, Dims>& rhs) {
   MATHFU_VECTOR_OPERATOR(lhs.data_[i] - rhs[i]);
 }
 
@@ -853,7 +857,7 @@ inline Vector<T, Dims> operator-(const Vector<T, Dims>& lhs,
 /// @param s A scalar to multiply the vector with.
 /// @return A new vector containing the result.
 template <class T, int Dims>
-inline Vector<T, Dims> operator*(const Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims> operator*(const Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATOR(v.data_[i] * s);
 }
 
@@ -863,7 +867,7 @@ inline Vector<T, Dims> operator*(const Vector<T, Dims>& v, T s) {
 /// @param s A scalar to add to the vector.
 /// @return A new vector containing the result.
 template <class T, int Dims>
-inline Vector<T, Dims> operator+(const Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims> operator+(const Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATOR(v.data_[i] + s);
 }
 
@@ -873,7 +877,7 @@ inline Vector<T, Dims> operator+(const Vector<T, Dims>& v, T s) {
 /// @param s A scalar to subtract from a vector.
 /// @return A new vector that stores the result.
 template <class T, int Dims>
-inline Vector<T, Dims> operator-(const Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims> operator-(const Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATOR(v.data_[i] - s);
 }
 
@@ -883,8 +887,8 @@ inline Vector<T, Dims> operator-(const Vector<T, Dims>& v, T s) {
 /// @param rhs Second vector to add.
 /// @return A reference to the input <b>v</b> vector.
 template <class T, int Dims>
-inline Vector<T, Dims>& operator+=(Vector<T, Dims>& lhs,
-                                   const Vector<T, Dims>& rhs) {
+constexpr Vector<T, Dims>& operator+=(Vector<T, Dims>& lhs,
+                                      const Vector<T, Dims>& rhs) {
   MATHFU_VECTOR_OPERATION(lhs.data_[i] += rhs[i]);
   return lhs;
 }
@@ -895,8 +899,8 @@ inline Vector<T, Dims>& operator+=(Vector<T, Dims>& lhs,
 /// @param rhs Second vector to subtract by.
 /// @return A reference to the input <b>v</b> vector.
 template <class T, int Dims>
-inline Vector<T, Dims>& operator-=(Vector<T, Dims>& lhs,
-                                   const Vector<T, Dims>& rhs) {
+constexpr Vector<T, Dims>& operator-=(Vector<T, Dims>& lhs,
+                                      const Vector<T, Dims>& rhs) {
   MATHFU_VECTOR_OPERATION(lhs.data_[i] -= rhs[i]);
   return lhs;
 }
@@ -907,7 +911,7 @@ inline Vector<T, Dims>& operator-=(Vector<T, Dims>& lhs,
 /// @param s A scalar to multiply the vector with.
 /// @return A reference to the input <b>v</b> vector.
 template <class T, int Dims>
-inline Vector<T, Dims>& operator*=(Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims>& operator*=(Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATION(v.data_[i] *= s);
   return v;
 }
@@ -918,7 +922,7 @@ inline Vector<T, Dims>& operator*=(Vector<T, Dims>& v, T s) {
 /// @param s A scalar to divide the vector by.
 /// @return A reference to the input <b>v</b> vector.
 template <class T, int Dims>
-inline Vector<T, Dims>& operator/=(Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims>& operator/=(Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATION(v.data_[i] /= s);
   return v;
 }
@@ -929,7 +933,7 @@ inline Vector<T, Dims>& operator/=(Vector<T, Dims>& v, T s) {
 /// @param s A scalar to add the vector to.
 /// @return A reference to the input <b>v</b> vector.
 template <class T, int Dims>
-inline Vector<T, Dims>& operator+=(Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims>& operator+=(Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATION(v.data_[i] += s);
   return v;
 }
@@ -940,7 +944,7 @@ inline Vector<T, Dims>& operator+=(Vector<T, Dims>& v, T s) {
 /// @param s A scalar to subtract from the vector.
 /// @return A reference to the input <b>v</b> vector.
 template <class T, int Dims>
-inline Vector<T, Dims>& operator-=(Vector<T, Dims>& v, T s) {
+constexpr Vector<T, Dims>& operator-=(Vector<T, Dims>& v, T s) {
   MATHFU_VECTOR_OPERATION(v.data_[i] -= s);
   return v;
 }
@@ -951,8 +955,8 @@ inline Vector<T, Dims>& operator-=(Vector<T, Dims>& v, T s) {
 /// @param v2 Second vector.
 /// @return The hadamard product of v1 and v2.
 template <class T, int Dims>
-inline Vector<T, Dims> HadamardProductHelper(const Vector<T, Dims>& v1,
-                                             const Vector<T, Dims>& v2) {
+constexpr Vector<T, Dims> HadamardProductHelper(const Vector<T, Dims>& v1,
+                                                const Vector<T, Dims>& v2) {
   MATHFU_VECTOR_OPERATOR(v1[i] * v2[i]);
 }
 
@@ -962,8 +966,8 @@ inline Vector<T, Dims> HadamardProductHelper(const Vector<T, Dims>& v1,
 /// @param v2 Second vector (denominator).
 /// @return The componentwise quotient of v1 and v2.
 template <class T, int Dims>
-inline Vector<T, Dims> HadamardDivideHelper(const Vector<T, Dims>& v1,
-                                            const Vector<T, Dims>& v2) {
+constexpr Vector<T, Dims> HadamardDivideHelper(const Vector<T, Dims>& v1,
+                                               const Vector<T, Dims>& v2) {
   MATHFU_VECTOR_OPERATOR(v1[i] / v2[i]);
 }
 
@@ -974,8 +978,8 @@ inline Vector<T, Dims> HadamardDivideHelper(const Vector<T, Dims>& v1,
 /// @param v2 Second vector.
 /// @return The cross product of v1 and v2.
 template <class T>
-inline Vector<T, 3> CrossProductHelper(const Vector<T, 3>& v1,
-                                       const Vector<T, 3>& v2) {
+constexpr Vector<T, 3> CrossProductHelper(const Vector<T, 3>& v1,
+                                          const Vector<T, 3>& v2) {
   return Vector<T, 3>(v1[1] * v2[2] - v1[2] * v2[1],
                       v1[2] * v2[0] - v1[0] * v2[2],
                       v1[0] * v2[1] - v1[1] * v2[0]);
@@ -990,7 +994,7 @@ inline Vector<T, 3> CrossProductHelper(const Vector<T, 3>& v1,
 /// @param v2 Second vector.
 /// @return The scalar cross product of v1 and v2.
 template <class T>
-inline T CrossProductHelper(const Vector<T, 2>& v1, const Vector<T, 2>& v2) {
+constexpr T CrossProductHelper(const Vector<T, 2>& v1, const Vector<T, 2>& v2) {
   return v1[0] * v2[1] - v1[1] * v2[0];
 }
 
@@ -999,7 +1003,7 @@ inline T CrossProductHelper(const Vector<T, 2>& v1, const Vector<T, 2>& v2) {
 /// @param v Vector to get the squared length of.
 /// @return The squared length of the vector.
 template <class T, int Dims>
-inline T LengthSquaredHelper(const Vector<T, Dims>& v) {
+constexpr T LengthSquaredHelper(const Vector<T, Dims>& v) {
   return DotProductHelper(v, v);
 }
 
@@ -1045,8 +1049,9 @@ inline Vector<T, Dims> NormalizedHelper(const Vector<T, Dims>& v) {
 /// @param percent Percentage from v1 to v2, usually in the range 0.0...1.0.
 /// @return The lerped mixture of v1 and v2.
 template <class T, int Dims>
-inline Vector<T, Dims> LerpHelper(const Vector<T, Dims>& v1,
-                                  const Vector<T, Dims>& v2, const T percent) {
+constexpr Vector<T, Dims> LerpHelper(const Vector<T, Dims>& v1,
+                                     const Vector<T, Dims>& v2,
+                                     const T percent) {
   MATHFU_VECTOR_OPERATOR(v1[i] + (v2[i] - v1[i]) * percent);
 }
 
@@ -1056,8 +1061,8 @@ inline Vector<T, Dims> LerpHelper(const Vector<T, Dims>& v1,
 /// @param v2 Second vector.
 /// @return Max value of v1 and v2.
 template <class T, int Dims>
-inline Vector<T, Dims> MaxHelper(const Vector<T, Dims>& v1,
-                                 const Vector<T, Dims>& v2) {
+constexpr Vector<T, Dims> MaxHelper(const Vector<T, Dims>& v1,
+                                    const Vector<T, Dims>& v2) {
   Vector<T, Dims> result;
   MATHFU_VECTOR_OPERATION(result[i] = std::max(v1[i], v2[i]));
   return result;
@@ -1069,8 +1074,8 @@ inline Vector<T, Dims> MaxHelper(const Vector<T, Dims>& v1,
 /// @param v2 Second vector.
 /// @return Min value of v1 and v2.
 template <class T, int Dims>
-inline Vector<T, Dims> MinHelper(const Vector<T, Dims>& v1,
-                                 const Vector<T, Dims>& v2) {
+constexpr Vector<T, Dims> MinHelper(const Vector<T, Dims>& v1,
+                                    const Vector<T, Dims>& v2) {
   Vector<T, Dims> result;
   MATHFU_VECTOR_OPERATION(result[i] = std::min(v1[i], v2[i]));
   return result;
@@ -1137,8 +1142,8 @@ bool InRange(const Vector<T, Dims>& val, const Vector<T, Dims>& range_start,
 /// @param onto The vector to project onto. Must be non-zero.
 /// @return The vector projection of v onto onto.
 template <class T, int Dims>
-inline Vector<T, Dims> ProjectHelper(const Vector<T, Dims>& v,
-                                     const Vector<T, Dims>& onto) {
+constexpr Vector<T, Dims> ProjectHelper(const Vector<T, Dims>& v,
+                                        const Vector<T, Dims>& onto) {
   return onto * (DotProductHelper(v, onto) / DotProductHelper(onto, onto));
 }
 
@@ -1149,8 +1154,8 @@ inline Vector<T, Dims> ProjectHelper(const Vector<T, Dims>& v,
 /// @param from The vector to reject from. Must be non-zero.
 /// @return The vector rejection of v from from.
 template <class T, int Dims>
-inline Vector<T, Dims> RejectHelper(const Vector<T, Dims>& v,
-                                    const Vector<T, Dims>& from) {
+constexpr Vector<T, Dims> RejectHelper(const Vector<T, Dims>& v,
+                                       const Vector<T, Dims>& from) {
   return v - ProjectHelper(v, from);
 }
 
@@ -1161,8 +1166,8 @@ inline Vector<T, Dims> RejectHelper(const Vector<T, Dims>& v,
 /// @return The reflected direction.
 /// Matches GLSL reflect() semantics.
 template <class T, int Dims>
-inline Vector<T, Dims> ReflectHelper(const Vector<T, Dims>& incident,
-                                     const Vector<T, Dims>& normal) {
+constexpr Vector<T, Dims> ReflectHelper(const Vector<T, Dims>& incident,
+                                        const Vector<T, Dims>& normal) {
   return incident
          - normal * (T(2) * Vector<T, Dims>::DotProduct(incident, normal));
 }
@@ -1210,8 +1215,8 @@ bool InRange2D(const Vector<T, 2>& val, const Vector<T, 2>& range_start,
 /// @return The dot product of v1 and v2.
 /// @related Vector
 template <class T, int Dims>
-static inline T DotProductHelper(const Vector<T, Dims>& v1,
-                                 const Vector<T, Dims>& v2) {
+static constexpr T DotProductHelper(const Vector<T, Dims>& v1,
+                                    const Vector<T, Dims>& v2) {
   T result = T(0);
   MATHFU_VECTOR_OPERATION(result += v1[i] * v2[i]);
   return result;
@@ -1220,24 +1225,24 @@ static inline T DotProductHelper(const Vector<T, Dims>& v1,
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-static inline T DotProductHelper(const Vector<T, 2>& v1,
-                                 const Vector<T, 2>& v2) {
+static constexpr T DotProductHelper(const Vector<T, 2>& v1,
+                                    const Vector<T, 2>& v2) {
   return v1[0] * v2[0] + v1[1] * v2[1];
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-static inline T DotProductHelper(const Vector<T, 3>& v1,
-                                 const Vector<T, 3>& v2) {
+static constexpr T DotProductHelper(const Vector<T, 3>& v1,
+                                    const Vector<T, 3>& v2) {
   return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2];
 }
 /// @endcond
 
 /// @cond MATHFU_INTERNAL
 template <class T>
-static inline T DotProductHelper(const Vector<T, 4>& v1,
-                                 const Vector<T, 4>& v2) {
+static constexpr T DotProductHelper(const Vector<T, 4>& v1,
+                                    const Vector<T, 4>& v2) {
   return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3];
 }
 /// @endcond
@@ -1283,7 +1288,7 @@ static inline CompatibleT ToTypeHelper(const Vector<T, Dims>& v) {
 /// @param v2 Vector to multiply.
 /// @return Scalar dot product result.
 template <class T, int d>
-inline T dot(const Vector<T, d>& v1, const Vector<T, d>& v2) {
+constexpr T dot(const Vector<T, d>& v1, const Vector<T, d>& v2) {
   return Vector<T, d>::DotProduct(v1, v2);
 }
 
@@ -1293,7 +1298,7 @@ inline T dot(const Vector<T, d>& v1, const Vector<T, d>& v2) {
 /// @param v2 Vector to multiply.
 /// @return 3-dimensional vector that contains the result.
 template <class T>
-inline Vector<T, 3> cross(const Vector<T, 3>& v1, const Vector<T, 3>& v2) {
+constexpr Vector<T, 3> cross(const Vector<T, 3>& v1, const Vector<T, 3>& v2) {
   return Vector<T, 3>::CrossProduct(v1, v2);
 }
 
@@ -1303,7 +1308,7 @@ inline Vector<T, 3> cross(const Vector<T, 3>& v1, const Vector<T, 3>& v2) {
 /// @param v2 Second vector.
 /// @return Scalar cross product result.
 template <class T>
-inline T cross(const Vector<T, 2>& v1, const Vector<T, 2>& v2) {
+constexpr T cross(const Vector<T, 2>& v1, const Vector<T, 2>& v2) {
   return Vector<T, 2>::CrossProduct(v1, v2);
 }
 
@@ -1323,7 +1328,7 @@ inline Vector<T, d> normalize(const Vector<T, d>& v) {
 
 /// @brief Specialized version of RoundUpToPowerOf2 for vector.
 template <typename T, int Dims>
-inline Vector<T, Dims> RoundUpToPowerOf2(const Vector<T, Dims>& v) {
+constexpr Vector<T, Dims> RoundUpToPowerOf2(const Vector<T, Dims>& v) {
   Vector<T, Dims> ret;
   MATHFU_VECTOR_OPERATION(ret(i) = RoundUpToPowerOf2(v(i)));
   return ret;
@@ -1331,9 +1336,9 @@ inline Vector<T, Dims> RoundUpToPowerOf2(const Vector<T, Dims>& v) {
 
 /// @brief Specialized version of Clamp for vector.
 template <typename T, int Dims>
-inline Vector<T, Dims> Clamp(const Vector<T, Dims>& x,
-                             const Vector<T, Dims>& lower,
-                             const Vector<T, Dims>& upper) {
+constexpr Vector<T, Dims> Clamp(const Vector<T, Dims>& x,
+                                const Vector<T, Dims>& lower,
+                                const Vector<T, Dims>& upper) {
   return Vector<T, Dims>::Max(lower, Vector<T, Dims>::Min(x, upper));
 }
 
@@ -1343,8 +1348,8 @@ inline Vector<T, Dims> Clamp(const Vector<T, Dims>& x,
 /// @param onto The vector to project onto. Must be non-zero.
 /// @return The vector projection of v onto onto.
 template <class T, int Dims>
-inline Vector<T, Dims> Project(const Vector<T, Dims>& v,
-                               const Vector<T, Dims>& onto) {
+constexpr Vector<T, Dims> Project(const Vector<T, Dims>& v,
+                                  const Vector<T, Dims>& onto) {
   return Vector<T, Dims>::Project(v, onto);
 }
 
@@ -1355,8 +1360,8 @@ inline Vector<T, Dims> Project(const Vector<T, Dims>& v,
 /// @param from The vector to reject from. Must be non-zero.
 /// @return The vector rejection of v from from.
 template <class T, int Dims>
-inline Vector<T, Dims> Reject(const Vector<T, Dims>& v,
-                              const Vector<T, Dims>& from) {
+constexpr Vector<T, Dims> Reject(const Vector<T, Dims>& v,
+                                 const Vector<T, Dims>& from) {
   return Vector<T, Dims>::Reject(v, from);
 }
 /// @}


### PR DESCRIPTION
## Summary
- Mark constructors, accessors, arithmetic operators, comparison operators, and geometry functions as `constexpr` across all 17 header files
- Functions using `sqrt`, `sin`, `cos`, `atan2`, `fabs`, `memcpy`, or SIMD intrinsics remain `inline` since those operations are not constexpr-eligible
- Float SIMD specializations (e.g. `operator*(Matrix<float,3,3>, Vector<float,3>)`) and float constants that depend on non-literal SIMD types remain `inline`/`const`
- Double and int constants promoted from `inline const` to `inline constexpr`

## Changes
- **vector.h**: All operators, helpers (DotProduct, HadamardProduct, CrossProduct, Lerp, Max, Min, Project, Reject, Reflect, etc.), and free functions → constexpr. Length/Normalize/Distance/Angle/Refract kept inline.
- **vector_2.h, vector_3.h, vector_4.h**: All non-SIMD specialization functions → constexpr where eligible
- **matrix.h**: Constructors, accessors, arithmetic, transpose, identity, outer product, hadamard product, transform helpers → constexpr. Inverse, LookAt, Perspective, Ortho, trig-based rotations kept inline.
- **quaternion.h**: Constructors, accessors, conjugate, inverse, rotate, dot product, operators → constexpr. Slerp, ToMatrix, FromAngleAxis, normalize kept inline.
- **rect.h, aabb.h, sphere.h, capsule.h**: All member functions and free operators → constexpr (except sqrt-dependent ones like Sphere::Contains(Sphere), Capsule::Length)
- **ray.h**: Ray/Line/LineSegment constructors, PointAt, Center, LengthSquared, ClosestPoint → constexpr. Length, Direction, FromPoints kept inline.
- **plane.h**: Constructor, FromPointNormal, SignedDistance, ProjectPoint, Flipped → constexpr. FromPoints kept inline.
- **transform.h**: 3-arg and 2-arg constructors, TransformPoint, TransformDirection, Inverse, operator* → constexpr. Default/position-only constructors and Identity/ToMatrix kept inline.
- **frustum.h**: 6-plane constructor, ContainsPoint, IntersectsAABB, IntersectsSphere, GetPlane → constexpr. FromViewProjection and NormalizePlane kept inline.
- **intersections.h**: AABBIntersectsAABB, SphereIntersectsSphere, SphereIntersectsAABB, PointInAABB, PointInSphere → constexpr. Ray intersection functions and PointOnPlane kept inline.
- **utilities.h**: Clamp, Lerp, InRange, integral RoundUpToPowerOf2, RoundUpToTypeBoundary → constexpr
- **constants.h**: Double/int vector constants and Quaternion<double> → `inline constexpr`

## Testing
- All 5347 existing tests pass
- Build succeeds in Release mode with MSVC (Visual Studio 17 2022)
- clang-format applied to all changed files

Resolves #40.