### PR TITLE
Add operator* for AffineTransform2D point transformation

### DIFF
--- a/include/mathkata/affine_transform_2d.h
+++ b/include/mathkata/affine_transform_2d.h
@@ -350,6 +350,17 @@ constexpr AffineTransform2D<T> operator*(const AffineTransform2D<T>& lhs,
   return result;
 }
 
+/// @brief Transform a 2D point by an affine transform.
+///
+/// @param transform The transform to apply.
+/// @param point The point to transform.
+/// @return The transformed point.
+template <class T>
+constexpr Vector<T, 2> operator*(const AffineTransform2D<T>& transform,
+                                 const Vector<T, 2>& point) {
+  return transform.TransformPoint(point);
+}
+
 /// @brief Compose two 2D affine transforms in-place.
 ///
 /// @param lhs Left-hand side transform, modified in-place.


### PR DESCRIPTION
## Summary
- Adds `operator*(AffineTransform2D, Vector<T, 2>)` as shorthand for `TransformPoint()`
- Enables natural mathematical notation: `worldPos = transform * localPos`

Closes #166

## Test plan
- [x] All 5366 tests pass
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)