### PR TITLE
Add convenience type aliases for AffineTransform2D and Color

### DIFF
--- a/include/mathkata/glsl_mappings.h
+++ b/include/mathkata/glsl_mappings.h
@@ -17,6 +17,8 @@
 #ifndef MATHKATA_GLSL_MAPPINGS_H_
 #define MATHKATA_GLSL_MAPPINGS_H_
 
+#include "mathkata/affine_transform_2d.h"
+#include "mathkata/color.h"
 #include "mathkata/matrix.h"
 #include "mathkata/quaternion.h"
 #include "mathkata/rect.h"
@@ -83,6 +85,12 @@ typedef Rect<float> rectf;
 typedef Rect<double> rectd;
 /// Rect composed of type <code>int</code>.
 typedef Rect<int> recti;
+
+/// 2D affine transform composed of type <code>float</code>.
+typedef AffineTransform2D<float> affine2d;
+
+/// RGBA color with 8-bit components.
+typedef Color color;
 
 /// @brief Reflect incident vector off a surface with the given normal.
 ///


### PR DESCRIPTION
## Summary
- Adds `affine2d` alias for `AffineTransform2D<float>` in `glsl_mappings.h`
- Adds `color` alias for `Color` in `glsl_mappings.h`
- Consistent with existing GLSL-style aliases like `vec2`, `mat4`, `rectf`

Closes #167

## Test plan
- [x] All 5366 tests pass
- [x] clang-format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)