### PR TITLE
Add vcpkg registry update workflow

### DIFF
--- a/.github/workflows/update-vcpkg-registry.yml
+++ b/.github/workflows/update-vcpkg-registry.yml
@@ -1,0 +1,12 @@
+name: Update vcpkg Registry
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  update-port:
+    uses: alexames/vcpkg-registry/.github/workflows/update-port.yml@main
+    secrets:
+      registry-token: ${{ secrets.VCPKG_REGISTRY_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically updates the vcpkg registry when a version tag (vX.Y.Z) is pushed.